### PR TITLE
Enable debuggable build type for debugging

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -38,6 +38,10 @@ android {
             shrinkResources false
             minifyEnabled false
         }
+        debug {
+            debuggable true
+            applicationIdSuffix ".debug"
+        }
     }
 
     splits {


### PR DESCRIPTION
This PR introduces a debuggable build variant into the project. Now, with the flag `debuggable true` and `applicationIdSuffix` set to `.debug`, devs are able to generate and run a debuggable version of the app. This is especially helpful on real devices because it helps prevent package name conflicts between `debug` and `release` versions and allows them to be installed side-by-side. This change will thus provide more effective identification and fixing of issues during the development process.