### PR TITLE
Simplify the impl of sendIntentToService functions

### DIFF
--- a/app/src/main/java/org/torproject/android/ConnectFragment.kt
+++ b/app/src/main/java/org/torproject/android/ConnectFragment.kt
@@ -25,6 +25,7 @@ import net.freehaven.tor.control.TorControlCommands
 
 import org.torproject.android.core.NetworkUtils.isNetworkAvailable
 import org.torproject.android.core.putNotSystem
+import org.torproject.android.core.sendIntentToService
 import org.torproject.android.service.OrbotConstants
 import org.torproject.android.service.OrbotService
 import org.torproject.android.service.util.Prefs
@@ -97,8 +98,8 @@ class ConnectFragment : Fragment(), ConnectionHelperCallbacks,
     }
 
     private fun stopTorAndVpn() {
-        sendIntentToService(OrbotConstants.ACTION_STOP)
-        sendIntentToService(OrbotConstants.ACTION_STOP_VPN)
+        requireContext().sendIntentToService(OrbotConstants.ACTION_STOP)
+        requireContext().sendIntentToService(OrbotConstants.ACTION_STOP_VPN)
     }
 
     private fun stopAnimations() {
@@ -107,7 +108,7 @@ class ConnectFragment : Fragment(), ConnectionHelperCallbacks,
     }
 
     private fun sendNewnymSignal() {
-        sendIntentToService(TorControlCommands.SIGNAL_NEWNYM)
+        requireContext().sendIntentToService(TorControlCommands.SIGNAL_NEWNYM)
         ivOnion.animate().alpha(0f).duration = 500
         Handler().postDelayed({ ivOnion.animate().alpha(1f).duration = 500 }, 600)
     }
@@ -133,9 +134,9 @@ class ConnectFragment : Fragment(), ConnectionHelperCallbacks,
             }
             // todo we need to add a power user mode for users to start the VPN without tor
             Prefs.putUseVpn(!Prefs.isPowerUserMode())
-            sendIntentToService(OrbotConstants.ACTION_START)
+            requireContext().sendIntentToService(OrbotConstants.ACTION_START)
 
-            if (!Prefs.isPowerUserMode()) sendIntentToService(OrbotConstants.ACTION_START_VPN)
+            if (!Prefs.isPowerUserMode()) requireContext().sendIntentToService(OrbotConstants.ACTION_START_VPN)
         }
     }
 
@@ -161,7 +162,7 @@ class ConnectFragment : Fragment(), ConnectionHelperCallbacks,
         } else if (requestCode == OrbotActivity.REQUEST_CODE_SETTINGS && resultCode == AppCompatActivity.RESULT_OK) {
             // todo respond to language change extra data here...
         } else if (requestCode == OrbotActivity.REQUEST_VPN_APP_SELECT && resultCode == AppCompatActivity.RESULT_OK) {
-            sendIntentToService(OrbotConstants.ACTION_RESTART_VPN) // is this enough todo?
+            requireContext().sendIntentToService(OrbotConstants.ACTION_RESTART_VPN) // is this enough todo?
             refreshMenuList(requireContext())
         }
     }
@@ -324,7 +325,7 @@ class ConnectFragment : Fragment(), ConnectionHelperCallbacks,
         //tor format expects "{" for country code
         Prefs.setExitNodes("{$exitNode}")
 
-        sendIntentToService(
+        requireContext().sendIntentToService(
             Intent(
                 requireActivity(),
                 OrbotService::class.java
@@ -332,16 +333,5 @@ class ConnectFragment : Fragment(), ConnectionHelperCallbacks,
         )
 
         refreshMenuList(requireContext())
-    }
-
-
-    /** Sends intent to service, first modifying it to indicate it is not from the system */
-    private fun sendIntentToService(intent: Intent) =
-        ContextCompat.startForegroundService(requireActivity(), intent.putNotSystem())
-
-    private fun sendIntentToService(action: String) {
-        sendIntentToService(Intent(requireActivity(), OrbotService::class.java).apply {
-            this.action = action
-        })
     }
 }

--- a/app/src/main/java/org/torproject/android/KindnessFragment.kt
+++ b/app/src/main/java/org/torproject/android/KindnessFragment.kt
@@ -1,18 +1,17 @@
 package org.torproject.android
 
-import android.content.Intent
 import android.os.Bundle
-import androidx.fragment.app.Fragment
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.Button
 import android.widget.TextView
+
 import androidx.appcompat.widget.SwitchCompat
-import androidx.core.content.ContextCompat
-import org.torproject.android.core.putNotSystem
+import androidx.fragment.app.Fragment
+
+import org.torproject.android.core.sendIntentToService
 import org.torproject.android.service.OrbotConstants
-import org.torproject.android.service.OrbotService
 import org.torproject.android.service.util.Prefs
 
 class KindnessFragment : Fragment() {
@@ -41,7 +40,7 @@ class KindnessFragment : Fragment() {
         swVolunteerMode.setOnCheckedChangeListener { _, isChecked ->
             Prefs.setBeSnowflakeProxy(isChecked)
             showPanelStatus(isChecked)
-            sendIntentToService(OrbotConstants.CMD_SNOWFLAKE_PROXY)
+            requireContext().sendIntentToService(OrbotConstants.CMD_SNOWFLAKE_PROXY)
         }
 
         view.findViewById<TextView>(R.id.swVolunteerAdjust).setOnClickListener {
@@ -54,13 +53,6 @@ class KindnessFragment : Fragment() {
 
         showPanelStatus(Prefs.beSnowflakeProxy())
         return view
-    }
-
-    private fun sendIntentToService(action: String) {
-        val intent = Intent(requireContext(), OrbotService::class.java)
-            .setAction(action)
-            .putNotSystem()
-        ContextCompat.startForegroundService(requireContext(), intent)
     }
 
     private fun showPanelStatus(isActivated: Boolean) {

--- a/app/src/main/java/org/torproject/android/MoreFragment.kt
+++ b/app/src/main/java/org/torproject/android/MoreFragment.kt
@@ -9,11 +9,12 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.ListView
 import android.widget.TextView
-import androidx.core.content.ContextCompat
+
 import androidx.fragment.app.Fragment
+
 import org.torproject.android.OrbotActivity.Companion.REQUEST_CODE_SETTINGS
 import org.torproject.android.OrbotActivity.Companion.REQUEST_VPN_APP_SELECT
-import org.torproject.android.core.putNotSystem
+import org.torproject.android.core.sendIntentToService
 import org.torproject.android.core.ui.SettingsActivity
 import org.torproject.android.service.OrbotConstants
 import org.torproject.android.service.OrbotService
@@ -115,18 +116,10 @@ class MoreFragment : Fragment() {
             requireActivity(), OrbotService::class.java
         ).setAction(OrbotConstants.ACTION_STOP)
             .putExtra(OrbotConstants.ACTION_STOP_FOREGROUND_TASK, true)
-        sendIntentToService(OrbotConstants.ACTION_STOP_VPN)
-        sendIntentToService(killIntent)
+        requireContext().sendIntentToService(OrbotConstants.ACTION_STOP_VPN)
+        requireContext().sendIntentToService(killIntent)
         requireActivity().finish()
     }
-
-    private fun sendIntentToService(intent: Intent) =
-        ContextCompat.startForegroundService(requireActivity(), intent.putNotSystem())
-
-    private fun sendIntentToService(action: String) =
-        sendIntentToService(Intent(requireActivity(), OrbotService::class.java).apply {
-            this.action = action
-        })
 
     private fun showLog() {
         (activity as OrbotActivity).showLog()

--- a/app/src/main/java/org/torproject/android/OrbotActivity.kt
+++ b/app/src/main/java/org/torproject/android/OrbotActivity.kt
@@ -11,15 +11,18 @@ import android.content.pm.PackageManager
 import android.content.res.Configuration
 import android.os.Bundle
 import android.widget.*
+
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.core.content.ContextCompat
 import androidx.localbroadcastmanager.content.LocalBroadcastManager
 import androidx.navigation.findNavController
 import androidx.navigation.ui.setupWithNavController
+
 import com.google.android.material.bottomnavigation.BottomNavigationView
 import com.scottyab.rootbeer.RootBeer
+
 import org.torproject.android.core.LocaleHelper
-import org.torproject.android.core.putNotSystem
+import org.torproject.android.core.sendIntentToService
 import org.torproject.android.core.ui.BaseActivity
 import org.torproject.android.service.OrbotConstants
 import org.torproject.android.service.util.Prefs
@@ -167,18 +170,6 @@ class OrbotActivity : BaseActivity() {
         super.onDestroy()
         LocalBroadcastManager.getInstance(this).unregisterReceiver(orbotServiceBroadcastReceiver)
     }
-
-
-    /** Sends intent to service, first modifying it to indicate it is not from the system */
-    private fun sendIntentToService(intent: Intent) =
-        ContextCompat.startForegroundService(this, intent.putNotSystem())
-
-    private fun sendIntentToService(action: String) = sendIntentToService(android.content.Intent(
-        this,
-        org.torproject.android.service.OrbotService::class.java
-    ).apply {
-        this.action = action
-    })
 
     override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
         super.onActivityResult(requestCode, resultCode, data)

--- a/appcore/src/main/java/org/torproject/android/core/OrbotExtensionFunctions.kt
+++ b/appcore/src/main/java/org/torproject/android/core/OrbotExtensionFunctions.kt
@@ -1,11 +1,43 @@
 package org.torproject.android.core
 
+import android.content.Context
 import android.content.Intent
+
+import androidx.core.content.ContextCompat
+
 import org.torproject.android.service.OrbotConstants
+import org.torproject.android.service.OrbotService
 
 /**
- * Used to build Intents in Orbot, annoyingly we have to set this when passing Intents to
- * OrbotService to distinguish between Intents that are triggered from this codebase VS
- * Intents that the system sends to the VPNService on boot...
+ * Extension function for `Intent` to add a flag that marks the intent as originating
+ * from this application, rather than the system. This is necessary to distinguish
+ * between Intents sent by the system (e.g., during boot) and those triggered by Orbot.
+ *
+ * @return The modified Intent with the EXTRA_NOT_SYSTEM flag set to `true`.
  */
 fun Intent.putNotSystem(): Intent = this.putExtra(OrbotConstants.EXTRA_NOT_SYSTEM, true)
+
+/**
+ * Extension function for `Context` to send an Intent to a foreground service.
+ * It ensures the Intent is marked with the `EXTRA_NOT_SYSTEM` flag by calling
+ * the `putNotSystem()` extension.
+ *
+ * @param intent The Intent to be sent to the service.
+ */
+fun Context.sendIntentToService(intent: Intent) =
+    ContextCompat.startForegroundService(this, intent.putNotSystem())
+
+/**
+ * Overloaded extension function for `Context` to send an Intent to a foreground service
+ * using an action string. The action is applied to an Intent targeting the `OrbotService` class.
+ *
+ * Internally, it uses the `sendIntentToService(Intent)` method to dispatch the Intent.
+ *
+ * @param action The action string to set on the Intent before sending it to the service.
+ */
+fun Context.sendIntentToService(action: String) =
+    sendIntentToService(
+        Intent(this, OrbotService::class.java).apply {
+            this.action = action
+        }
+    )


### PR DESCRIPTION
The current approach is convoluted, with every class having their own definition for these function. This PR unifies all of these in the `OrbotExtension` functions and removes the need for code duplication.