### PR TITLE
Add support for PollInterval

### DIFF
--- a/orbotservice/src/main/java/org/torproject/android/service/OrbotService.java
+++ b/orbotservice/src/main/java/org/torproject/android/service/OrbotService.java
@@ -441,6 +441,7 @@ public class OrbotService extends VpnService implements OrbotConstants {
 
             if (mSnowflakeProxy == null) {
                 var capacity = 1;
+                var pollInterval = 120;
                 var stunServers = getCdnFront("snowflake-stun").split(",");
 
                 int randomIndex = mSecureRandGen.nextInt(stunServers.length);
@@ -452,6 +453,7 @@ public class OrbotService extends VpnService implements OrbotConstants {
                 mSnowflakeProxy = new SnowflakeProxy();
                 mSnowflakeProxy.setBrokerUrl(brokerUrl);
                 mSnowflakeProxy.setCapacity(capacity);
+                mSnowflakeProxy.setPollInterval(pollInterval);
                 mSnowflakeProxy.setRelayUrl(relayUrl);
                 mSnowflakeProxy.setStunServer(stunUrl);
                 mSnowflakeProxy.setNatProbeUrl(natProbeUrl);


### PR DESCRIPTION
The recomended value for mobile devices is 120 seconds. This should save some battery life on mobile devices.

Note: IPtProxy must be updated to 4.0.1 before this can be merged