### PR TITLE
Set minSDK to 21 to support legacy devices

### DIFF
--- a/app-tv/build.gradle
+++ b/app-tv/build.gradle
@@ -6,7 +6,7 @@ android {
 
     defaultConfig {
         applicationId "org.torproject.android.tv"
-        minSdk = 23
+        minSdk = 21
         targetSdk = 35
     }
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -22,7 +22,7 @@ android {
     defaultConfig {
         applicationId "org.torproject.android"
         versionName getVersionName()
-        minSdk = 23
+        minSdk = 21
         targetSdk = 35
         multiDexEnabled true
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"

--- a/appcore/build.gradle
+++ b/appcore/build.gradle
@@ -8,7 +8,7 @@ android {
     compileSdk = 35
 
     defaultConfig {
-        minSdk = 23
+        minSdk = 21
         targetSdk = 35
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"

--- a/intentintegrator/build.gradle
+++ b/intentintegrator/build.gradle
@@ -5,7 +5,7 @@ android {
     compileSdk = 35
 
     defaultConfig {
-        minSdk = 23
+        minSdk = 21
         targetSdk = 35
         consumerProguardFiles "consumer-rules.pro"
     }

--- a/orbotservice/build.gradle
+++ b/orbotservice/build.gradle
@@ -5,7 +5,7 @@ android {
     compileSdk = 35
 
     defaultConfig {
-        minSdk = 23
+        minSdk = 21
         targetSdk = 35
     }
 


### PR DESCRIPTION
This commit also requires the following change before merging: https://github.com/guardianproject/OrbotIPtProxy/pull/2