### PR TITLE
Center the Orbot activity vertically

### DIFF
--- a/app/src/main/res/layout/activity_orbot.xml
+++ b/app/src/main/res/layout/activity_orbot.xml
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
-
 <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent"
@@ -7,23 +6,24 @@
         xmlns:android="http://schemas.android.com/apk/res/android"
         xmlns:app="http://schemas.android.com/apk/res-auto">
 
-        <fragment
+    <fragment
             android:id="@+id/nav_fragment"
             android:name="androidx.navigation.fragment.NavHostFragment"
             android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:layout_marginTop="140dp"
+            android:layout_height="0dp"
             app:defaultNavHost="true"
+            app:layout_constraintTop_toTopOf="parent"
             app:layout_constraintBottom_toTopOf="@id/bottom_navigation"
             app:layout_constraintLeft_toLeftOf="parent"
             app:layout_constraintRight_toRightOf="parent"
-            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintVertical_bias="0.5"
             app:navGraph="@navigation/nav_graph" />
 
-        <com.google.android.material.bottomnavigation.BottomNavigationView
+    <com.google.android.material.bottomnavigation.BottomNavigationView
             android:id="@+id/bottom_navigation"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
+            android:background="@android:color/black"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintBottom_toBottomOf="parent"
@@ -31,4 +31,4 @@
             app:itemTextColor="@color/bottom_nav_color"
             app:itemIconTint="@color/bottom_nav_color" />
 
-    </androidx.constraintlayout.widget.ConstraintLayout>
+</androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
I consider 9440e723f29b9b282474b0a192f96811a588d12e to be a regression which makes the UI essentially unusable on smaller devices and tablets. Moreover, it adds too much padding and shifts the UI an excessive amount from the previous releases. This PR aims to center the UI and provide a more comfortable middle ground.

<table>
    <tr>
        <th>Before</th>
        <th>After</th>
    </tr>
    <tr>
        <td><img src="https://github.com/user-attachments/assets/bf18c0b2-995f-47f7-bb1a-701bb5c7211c" height="720px"></td>
        <td><img src="https://github.com/user-attachments/assets/a4de5197-20cf-48db-8e5b-b9a40e18bc90" height="720px"></td>
    </tr>
    <tr>
        <td><img src="https://github.com/user-attachments/assets/38f2c499-d596-4052-b98c-d5d2c93a3b18" height="720px"></td>
        <td><img src="https://github.com/user-attachments/assets/77c42b10-92fb-4b49-a6fd-2983a6fa472c" height="720px"></td>
    </tr>
    <tr>
        <td><img src="https://github.com/user-attachments/assets/20cbaec0-616f-4f89-9862-28c378ff9801" height="720px"></td>
        <td><img src="https://github.com/user-attachments/assets/62ec5db9-0c85-4ae9-bc6e-1293ea745830" height="720px"></td>
    </tr>
</table>

Closes #1261 

Tested on Pixel 8 API 34.