### PR TITLE
Fix constants and setting ports

### DIFF
--- a/app-tv/src/main/res/values-ar/strings.xml
+++ b/app-tv/src/main/res/values-ar/strings.xml
@@ -98,7 +98,7 @@
   <string name="pref_transport_summary">منفذ الشبكات الحاسوبية الذي يقدمه تور إلى البروكسي الشفاف (المنفذ 9040 او 0 عدم القدرة)</string>
   <string name="pref_transport_dialog">تهيئة منفذ البروكسي الشفاف</string>
   <string name="pref_dnsport_title">منفذ الشبكات الحاسوبية لنظام أسماء النطاقات الخاص ب تور</string>
-  <string name="pref_dnsport_summary">منفذ الشبكات الحاسوبية او بورت الذي يقدمه تور الى خدمة اسماء النطاق دي ان اس. (التقصير 5400 او 0 لعدم القدرة)</string>
+  <string name="pref_dnsport_summary">منفذ الشبكات الحاسوبية او بورت الذي يقدمه تور الى خدمة اسماء النطاق دي ان اس. (التقصير 9053 او 0 لعدم القدرة)</string>
   <string name="pref_dnsport_dialog">إعدادات بورت خادم اسماء النطاق</string>
   <string name="pref_torrc_title">ترتيبات خاصة بـ torrc</string>
   <string name="pref_torrc_summary">للخبراء فقط : أدخل أسطر ملف torrc مباشرةً</string>

--- a/app-tv/src/main/res/values-ay/strings.xml
+++ b/app-tv/src/main/res/values-ay/strings.xml
@@ -101,7 +101,7 @@
   <string name="pref_transport_summary">Toran Qhan Apnaqat Proxy apayañ thakh churañ munatapa (Nayra utt\'atatakix 9040, jiwt\'ayañatakix 0)</string>
   <string name="pref_transport_dialog">TransProxyn apayañ thakhinak mayjt\'ayaña</string>
   <string name="pref_dnsport_title">Tor DNS apayañ thakhi</string>
-  <string name="pref_dnsport_summary">Toran DNS apayañ thakhipa: (nayra utt\'atatakix 5400, jiwt\'ayañatakix 0)</string>
+  <string name="pref_dnsport_summary">Toran DNS apayañ thakhipa: (nayra utt\'atatakix 9053, jiwt\'ayañatakix 0)</string>
   <string name="pref_dnsport_dialog">DNS apayañ thakhinak mayjt\'ayaña</string>
   <string name="pref_torrc_title">Torrc mayjt\'ayaña</string>
   <string name="pref_torrc_summary">YATIRINAKATAKIKI: torrc apthapitan chiqak mayjt\'ayam</string>

--- a/app-tv/src/main/res/values-az/strings.xml
+++ b/app-tv/src/main/res/values-az/strings.xml
@@ -97,7 +97,7 @@ Tor: https://www.torproject.org</string>
   <string name="pref_transport_summary">Torun təklif etdiyi Port Transparent proksi işləyir (standart: 9040, yaxud söndürmək üçün 0) </string>
   <string name="pref_transport_dialog">TransProxy Port Config</string>
   <string name="pref_dnsport_title">Tor DNS Port</string>
-  <string name="pref_dnsport_summary">Torun təklif etdiyi Port DNS işləyir (standart: 5400, yaxud söndürmək üçün 0)</string>
+  <string name="pref_dnsport_summary">Torun təklif etdiyi Port DNS işləyir (standart: 9053, yaxud söndürmək üçün 0)</string>
   <string name="pref_dnsport_dialog">DNS Port Config</string>
   <string name="pref_torrc_title">Torrc Custom Config</string>
   <string name="pref_torrc_summary">YALNIZ EKSPERTLƏR: birbaşa torrc config xətlərini daxil edin</string>

--- a/app-tv/src/main/res/values-be/strings.xml
+++ b/app-tv/src/main/res/values-be/strings.xml
@@ -101,7 +101,7 @@
   <string name="pref_transport_summary">Порт, на якім Tor прапануе свой празрысты проксі (па змаўчанні: 9040, 0 - для адключэння)</string>
   <string name="pref_transport_dialog">Налада порта празрыстага проксі</string>
   <string name="pref_dnsport_title">Порт DNS Tor</string>
-  <string name="pref_dnsport_summary">Порт, на якім Tor прапануе свой DNS (па змаўчанні: 5400, 0 - для адключэння)</string>
+  <string name="pref_dnsport_summary">Порт, на якім Tor прапануе свой DNS (па змаўчанні: 9053, 0 - для адключэння)</string>
   <string name="pref_dnsport_dialog">Налада порта DNS</string>
   <string name="pref_torrc_title">Карыстальніцкія налады Torrc</string>
   <string name="pref_torrc_summary">ТОЛЬКІ ДЛЯ ЭКСПЕРТАЎ: унясіце налады наўпрост у радкі файла канфігурацыі torrc</string>

--- a/app-tv/src/main/res/values-bg/strings.xml
+++ b/app-tv/src/main/res/values-bg/strings.xml
@@ -97,7 +97,7 @@
   <string name="pref_transport_summary">Порт, на който Tor предлага своето Transparent прокси прокси(подразбиране: 9040 или 0, за да забраниш)</string>
   <string name="pref_transport_dialog">TransProxy Port Config</string>
   <string name="pref_dnsport_title">Tor DNS Port</string>
-  <string name="pref_dnsport_summary">Порт, на който Tor предлага своят DNS (подразбиране: 5400 или 0, за да забраниш)</string>
+  <string name="pref_dnsport_summary">Порт, на който Tor предлага своят DNS (подразбиране: 9053 или 0, за да забраниш)</string>
   <string name="pref_dnsport_dialog">DNS Port Config</string>
   <string name="pref_torrc_title">Torrc Custom Config</string>
   <string name="pref_torrc_summary">САМО ЗА ЕКСПЕРТИ: въведи директно torrc конфигурационният код</string>

--- a/app-tv/src/main/res/values-ca/strings.xml
+++ b/app-tv/src/main/res/values-ca/strings.xml
@@ -102,7 +102,7 @@
   <string name="pref_transport_summary">Port que ofereix el seu servidor intermediari transparent al Tor (per defecte: 9040 or 0 per inhabilitar)</string>
   <string name="pref_transport_dialog">Configuració del port TransProxy</string>
   <string name="pref_dnsport_title">Port DNS del Tor</string>
-  <string name="pref_dnsport_summary">Port que ofereix les DNS al Tor (per defecte: 5400 or 0 per inhabilitar)</string>
+  <string name="pref_dnsport_summary">Port que ofereix les DNS al Tor (per defecte: 9053 or 0 per inhabilitar)</string>
   <string name="pref_dnsport_dialog">Configuració del port DNS</string>
   <string name="pref_torrc_title">Configuració personalitzada del Torrc</string>
   <string name="pref_torrc_summary">NOMÉS EXPERTS: Escriviu les línies de configuració directa del Torrc</string>

--- a/app-tv/src/main/res/values-cs-rCZ/strings.xml
+++ b/app-tv/src/main/res/values-cs-rCZ/strings.xml
@@ -96,7 +96,7 @@
   <string name="pref_transport_summary">Port, na kterém Tor nabízí transparentní proxy (default: 9040, 0 pro zakázání)</string>
   <string name="pref_transport_dialog">TransProxy nastavení portu</string>
   <string name="pref_dnsport_title">Tor DNS port</string>
-  <string name="pref_dnsport_summary">Port, na kterém Tor nabízí DNS (default: 5400, 0 pro zakázání)</string>
+  <string name="pref_dnsport_summary">Port, na kterém Tor nabízí DNS (default: 9053, 0 pro zakázání)</string>
   <string name="pref_dnsport_dialog">DNS nastavení portu</string>
   <string name="pref_torrc_title">Torrc vstastní konfigurace</string>
   <string name="pref_torrc_summary">POUZE PRO EXPERTY: zadejte přímo řádky nastavení torrc</string>

--- a/app-tv/src/main/res/values-de/strings.xml
+++ b/app-tv/src/main/res/values-de/strings.xml
@@ -102,7 +102,7 @@
   <string name="pref_transport_summary">Anschluss auf dem der Transparente Proxy von Tor bereitgestellt wird (Standard: 9040 oder 0 zum deaktivieren)</string>
   <string name="pref_transport_dialog">TransProxy Anschluss-Konfiguration</string>
   <string name="pref_dnsport_title">Tor DNS-Anschluss</string>
-  <string name="pref_dnsport_summary">Anschluss, auf dem Tor seinen DNS bereitstellt (Standard: 5400 oder 0 zum deaktivieren)</string>
+  <string name="pref_dnsport_summary">Anschluss, auf dem Tor seinen DNS bereitstellt (Standard: 9053 oder 0 zum deaktivieren)</string>
   <string name="pref_dnsport_dialog">DNS Anschluss Konfiguration</string>
   <string name="pref_torrc_title">Benutzerdefinierte Torrc-Konfiguration</string>
   <string name="pref_torrc_summary">NUR FÜR EXPERTEN: torrc-Konfigurationszeilen direkt eingeben</string>

--- a/app-tv/src/main/res/values-el/strings.xml
+++ b/app-tv/src/main/res/values-el/strings.xml
@@ -102,7 +102,7 @@
   <string name="pref_transport_summary">Θύρα που προσφέρει ο Tor στον Transparent Proxy του (προεπιλογή: 9040 ή 0 για απενεργοποίηση)</string>
   <string name="pref_transport_dialog">Διάρθρωση Θύρας TransProxy</string>
   <string name="pref_dnsport_title">Tor Θύρα DNS </string>
-  <string name="pref_dnsport_summary">Θύρα που προσφέρει ο Tor στο DNS του (προεπιλογή: 5400 ή 0 για απενεργοποίηση)</string>
+  <string name="pref_dnsport_summary">Θύρα που προσφέρει ο Tor στο DNS του (προεπιλογή: 9053 ή 0 για απενεργοποίηση)</string>
   <string name="pref_dnsport_dialog">Διάρθρωση Θύρας DNS</string>
   <string name="pref_torrc_title">Torrc Custom Config</string>
   <string name="pref_torrc_summary">ΜΟΝΟ ΓΙΑ ΕΙΔΙΚΟΥΣ: πληκτρολογήστε απευθείας torrc config γραμμές</string>

--- a/app-tv/src/main/res/values-es/strings.xml
+++ b/app-tv/src/main/res/values-es/strings.xml
@@ -103,7 +103,7 @@ direcciones (o rangos). No prevalecen sobre las configuraciones de exclusión de
   <string name="pref_transport_summary">Puerto sobre el que Tor ofrece su Proxy Transparente (por defecto: 9040 o 0 para deshabilitarlo)</string>
   <string name="pref_transport_dialog">Configuración del puerto de TransProxy</string>
   <string name="pref_dnsport_title">Puerto DNS de Tor</string>
-  <string name="pref_dnsport_summary">Puerto sobre el que Tor ofrece su DNS (por defecto: 5400 o 0 para deshabilitarlo)</string>
+  <string name="pref_dnsport_summary">Puerto sobre el que Tor ofrece su DNS (por defecto: 9053 o 0 para deshabilitarlo)</string>
   <string name="pref_dnsport_dialog">Configuración del puerto DNS</string>
   <string name="pref_torrc_title">Configuración personalizada de torrc</string>
   <string name="pref_torrc_summary">SÓLO EXPERTOS: Introduzca directamente las líneas de configuración en el fichero torrc</string>

--- a/app-tv/src/main/res/values-eu/strings.xml
+++ b/app-tv/src/main/res/values-eu/strings.xml
@@ -102,7 +102,7 @@
   <string name="pref_transport_summary">Tor-ek bere Proxy gardena eskaintzeko ataka (Lehenetsia: 9040 edo 0 desgaitzeko)</string>
   <string name="pref_transport_dialog">Proxy gardenaren atakaren konfigurazioa</string>
   <string name="pref_dnsport_title">Tor DNS ataka</string>
-  <string name="pref_dnsport_summary">Tor-ek bere DNS-a eskaintzeko ataka (Lehenetsia: 5400 edo 0 desgaitzeko)</string>
+  <string name="pref_dnsport_summary">Tor-ek bere DNS-a eskaintzeko ataka (Lehenetsia: 9053 edo 0 desgaitzeko)</string>
   <string name="pref_dnsport_dialog">DNS atakaren konfigurazioa</string>
   <string name="pref_torrc_title">Torrc konfigurazio pertsonala</string>
   <string name="pref_torrc_summary">ADITUAK BESTERIK EZ: sartu torrc konfigurazio lerroak</string>

--- a/app-tv/src/main/res/values-fa/strings.xml
+++ b/app-tv/src/main/res/values-fa/strings.xml
@@ -102,7 +102,7 @@
   <string name="pref_transport_summary">پورتی که تور ارائه می دهد Transparent Proxy روی (پیش فرض:  9040 یا  0 برای غیرفعال کردن)</string>
   <string name="pref_transport_dialog">پیکربندی پورت Transproxy</string>
   <string name="pref_dnsport_title">پورت Tor DNS</string>
-  <string name="pref_dnsport_summary">پورتی که Tor ارائه می دهد آن DNS روی (به طور پیش فرض: 5400 یا 0 برای غیر فعال کردن)</string>
+  <string name="pref_dnsport_summary">پورتی که Tor ارائه می دهد آن DNS روی (به طور پیش فرض: 9053 یا 0 برای غیر فعال کردن)</string>
   <string name="pref_dnsport_dialog">پیکربندی پورت DNS</string>
   <string name="pref_torrc_title">پیکربندی سفارشی Torrc</string>
   <string name="pref_torrc_summary">فقط متخصصان:  enter direct torrc config lines</string>

--- a/app-tv/src/main/res/values-fi/strings.xml
+++ b/app-tv/src/main/res/values-fi/strings.xml
@@ -97,7 +97,7 @@
   <string name="pref_transport_summary">Portti, jossa Torin läpinäkyvä välityspalvelin on (oletus: 9040, 0 = poista käytöstä)</string>
   <string name="pref_transport_dialog">TransProxy-portin valinta</string>
   <string name="pref_dnsport_title">Tor DNS-portti</string>
-  <string name="pref_dnsport_summary">Portti, jossa Torin DNS on (oletus: 5400, 0 = poista käytöstä)</string>
+  <string name="pref_dnsport_summary">Portti, jossa Torin DNS on (oletus: 9053, 0 = poista käytöstä)</string>
   <string name="pref_dnsport_dialog">DNS-portin valinta</string>
   <string name="pref_torrc_title">Torrc:n mukautetut asetukset</string>
   <string name="pref_torrc_summary">VAIN ASIANTUNTIJAT: syötä torrc:n määritysrivejä suoraan</string>

--- a/app-tv/src/main/res/values-fr-rFR/strings.xml
+++ b/app-tv/src/main/res/values-fr-rFR/strings.xml
@@ -97,7 +97,7 @@
   <string name="pref_transport_summary">Port sur lequel Tor offre son mandataire transparent (par défaut : 9040 ou 0 pour le désactiver)</string>
   <string name="pref_transport_dialog">Configuration du port TransProxy</string>
   <string name="pref_dnsport_title">Port DNS de Tor</string>
-  <string name="pref_dnsport_summary">Port sur lequel Tor offre son DNS (par défaut : 5400 ou 0 pour le désactiver)</string>
+  <string name="pref_dnsport_summary">Port sur lequel Tor offre son DNS (par défaut : 9053 ou 0 pour le désactiver)</string>
   <string name="pref_dnsport_dialog">Configuration du port DNS</string>
   <string name="pref_torrc_title">Configuration personnalisée de Torrc</string>
   <string name="pref_torrc_summary">EXPERTS SEULEMENT : saisissez les lignes de configuration de torrc direct</string>

--- a/app-tv/src/main/res/values-fr/strings.xml
+++ b/app-tv/src/main/res/values-fr/strings.xml
@@ -102,7 +102,7 @@
   <string name="pref_transport_summary">Port sur lequel Tor offre son mandataire transparent (par défaut : 9040 ou 0 pour le désactiver)</string>
   <string name="pref_transport_dialog">Configuration du port TransProxy</string>
   <string name="pref_dnsport_title">Port DNS de Tor</string>
-  <string name="pref_dnsport_summary">Port sur lequel Tor offre son DNS (par défaut : 5400 ou 0 pour le désactiver)</string>
+  <string name="pref_dnsport_summary">Port sur lequel Tor offre son DNS (par défaut : 9053 ou 0 pour le désactiver)</string>
   <string name="pref_dnsport_dialog">Configuration du port DNS</string>
   <string name="pref_torrc_title">Configuration personnalisée de Torrc</string>
   <string name="pref_torrc_summary">EXPERTS SEULEMENT : saisissez les lignes de configuration de torrc direct</string>

--- a/app-tv/src/main/res/values-gl/strings.xml
+++ b/app-tv/src/main/res/values-gl/strings.xml
@@ -102,7 +102,7 @@
   <string name="pref_transport_summary">Porto no que Tor proporciona o Proxy Transparente (por omisión: 9040 ou 0 para desactivar)</string>
   <string name="pref_transport_dialog">Axuste do porto TransProxy</string>
   <string name="pref_dnsport_title">Porto DNS de Tor</string>
-  <string name="pref_dnsport_summary">Porto no que Tor ofrece o seu DNS (por omisión: 5400 ou 0 para desactivar)</string>
+  <string name="pref_dnsport_summary">Porto no que Tor ofrece o seu DNS (por omisión: 9053 ou 0 para desactivar)</string>
   <string name="pref_dnsport_dialog">Axuste do porto DNS</string>
   <string name="pref_torrc_title">Axuste Torrc personalizado</string>
   <string name="pref_torrc_summary">SO PARA EXPERTAS: introducir liñas de configuración directa torrc</string>

--- a/app-tv/src/main/res/values-hi/strings.xml
+++ b/app-tv/src/main/res/values-hi/strings.xml
@@ -103,7 +103,7 @@
   <string name="pref_transport_summary">पोर्ट उस टो पर अपने पारदर्शी प्रॉक्सी प्रदान करता है (डिफ़ॉल्ट: 9040 या अक्षम करने के लिए 0)</string>
   <string name="pref_transport_dialog">ट्रांसप्रोक्सी पोर्ट कॉन्फ़िग</string>
   <string name="pref_dnsport_title">टोरी डीएनएस पोर्ट</string>
-  <string name="pref_dnsport_summary">पोर्ट उस टोर पर अपने डीएनएस प्रदान करता है (डिफ़ॉल्ट: 5400 या अक्षम करने के लिए 0)</string>
+  <string name="pref_dnsport_summary">पोर्ट उस टोर पर अपने डीएनएस प्रदान करता है (डिफ़ॉल्ट: 9053 या अक्षम करने के लिए 0)</string>
   <string name="pref_dnsport_dialog">डीनस पोर्ट कॉन्फ़िग</string>
   <string name="pref_torrc_title">टोररक कस्टम कॉन्फ़िग</string>
   <string name="pref_torrc_summary">केवल विशेषज्ञ: प्रत्यक्ष टॉर्च कॉन्फ़िग लाइनें दर्ज करें</string>

--- a/app-tv/src/main/res/values-hr/strings.xml
+++ b/app-tv/src/main/res/values-hr/strings.xml
@@ -97,7 +97,7 @@
   <string name="pref_transport_summary">Port na kojem Tor pruža Transparentni Proxy (zadano: 9040, 0 za onemogućivanje)</string>
   <string name="pref_transport_dialog">Konfiguracija TransProxy porta</string>
   <string name="pref_dnsport_title">Tor DNS Port</string>
-  <string name="pref_dnsport_summary">Port na kojem Tor pruža DNS (zadano 5400, 0 za onemogućivanje)</string>
+  <string name="pref_dnsport_summary">Port na kojem Tor pruža DNS (zadano 9053, 0 za onemogućivanje)</string>
   <string name="pref_dnsport_dialog">Postavljanje DNS porta</string>
   <string name="pref_torrc_title">Torrc prilagođena konfiguracija</string>
   <string name="pref_torrc_summary">SAMO ZA STRUČNJAKE: unesite direktno torrc konfiguracijske linije</string>

--- a/app-tv/src/main/res/values-hu/strings.xml
+++ b/app-tv/src/main/res/values-hu/strings.xml
@@ -102,7 +102,7 @@
   <string name="pref_transport_summary">Port, amelyen a Tor a transzparens proxyt ajánl (alapértelmezett: 9040 vagy 0 a tiltáshoz)</string>
   <string name="pref_transport_dialog">TransProxy port konfiguráció</string>
   <string name="pref_dnsport_title">Tor DNS port</string>
-  <string name="pref_dnsport_summary">Port, amelyen a Tor a saját DNS-t ajánlja (alapértelmezett: 5400 vagy 0 a letiltáshoz)</string>
+  <string name="pref_dnsport_summary">Port, amelyen a Tor a saját DNS-t ajánlja (alapértelmezett: 9053 vagy 0 a letiltáshoz)</string>
   <string name="pref_dnsport_dialog">DNS port konfiguráció</string>
   <string name="pref_torrc_title">Torrc egyedi konfiguráció</string>
   <string name="pref_torrc_summary">CSAK SZAKÉRTŐKNEK: torrc konfigurációs sorok közvetlen beírása</string>

--- a/app-tv/src/main/res/values-in/strings.xml
+++ b/app-tv/src/main/res/values-in/strings.xml
@@ -97,7 +97,7 @@
   <string name="pref_transport_summary">Port tempat Proxy Transparan Tor aktif (standar: 9040 atau 0 untuk mematikan)</string>
   <string name="pref_transport_dialog">Konfigurasi Port TransProxy</string>
   <string name="pref_dnsport_title">Port DNS Tor</string>
-  <string name="pref_dnsport_summary">Port tempat DNS Tor aktif (standar: 5400 atau 0 untuk mematikan)</string>
+  <string name="pref_dnsport_summary">Port tempat DNS Tor aktif (standar: 9053 atau 0 untuk mematikan)</string>
   <string name="pref_dnsport_dialog">Konfigurasi Port DNS</string>
   <string name="pref_torrc_title">Konfigurasi Torrc</string>
   <string name="pref_torrc_summary">HANYA UNTUK AHLI: masukkan baris konfigurasi direct Torrc</string>

--- a/app-tv/src/main/res/values-is/strings.xml
+++ b/app-tv/src/main/res/values-is/strings.xml
@@ -102,7 +102,7 @@
   <string name="pref_transport_summary">Gátt sem Tor býður gegnsæja milliþjónsbeiningu á (sjálfgefið: 9040 eða 0 til að gera óvirkt)</string>
   <string name="pref_transport_dialog">Uppsetning gáttar fyrir gegnsæja milliþjónabeiningu (TransProxy)</string>
   <string name="pref_dnsport_title">Tor DNS-gátt</string>
-  <string name="pref_dnsport_summary">Gátt sem Tor býður DNS á (sjálfgefið: 5400 eða 0 til að gera óvirkt)</string>
+  <string name="pref_dnsport_summary">Gátt sem Tor býður DNS á (sjálfgefið: 9053 eða 0 til að gera óvirkt)</string>
   <string name="pref_dnsport_dialog">Stilling á DNS-gátt</string>
   <string name="pref_torrc_title">Sérsniðnar stillingar Torrc</string>
   <string name="pref_torrc_summary">AÐEINS SÉRFRÆÐINGAR: sláðu inn stillingarlínur beint í torrc</string>

--- a/app-tv/src/main/res/values-it/strings.xml
+++ b/app-tv/src/main/res/values-it/strings.xml
@@ -102,7 +102,7 @@
   <string name="pref_transport_summary">Porta sulla quale Tor offre il Proxy Trasparente (default: 9040 o 0 per disabilitare)</string>
   <string name="pref_transport_dialog">Configurazione Porta TransProxy</string>
   <string name="pref_dnsport_title">Porte Tor DNS</string>
-  <string name="pref_dnsport_summary">Porta sulla quale Tor offre i DNS (default: 5400 o 0 per disabilitare)</string>
+  <string name="pref_dnsport_summary">Porta sulla quale Tor offre i DNS (default: 9053 o 0 per disabilitare)</string>
   <string name="pref_dnsport_dialog">Configurazione porte DNS</string>
   <string name="pref_torrc_title">Configurazioni personalizzate di Torrc</string>
   <string name="pref_torrc_summary">SOLO ESPERTI: inserisci direttamente configurazioni torrc</string>

--- a/app-tv/src/main/res/values-ja/strings.xml
+++ b/app-tv/src/main/res/values-ja/strings.xml
@@ -102,7 +102,7 @@
   <string name="pref_transport_summary">Torが透過プロキシを提供するポート (デフォルト: 9040、0にすると無効)</string>
   <string name="pref_transport_dialog">透過プロキシポート設定</string>
   <string name="pref_dnsport_title">Tor DNS ポート</string>
-  <string name="pref_dnsport_summary">TorがDNSを提供するポート (デフォルト: 5400、0にすると無効)</string>
+  <string name="pref_dnsport_summary">TorがDNSを提供するポート (デフォルト: 9053、0にすると無効)</string>
   <string name="pref_dnsport_dialog">DNS ポート設定</string>
   <string name="pref_torrc_title">Torrc カスタム設定</string>
   <string name="pref_torrc_summary">上級者家のみ: 直接torrc設定行を入力します</string>

--- a/app-tv/src/main/res/values-ko/strings.xml
+++ b/app-tv/src/main/res/values-ko/strings.xml
@@ -97,7 +97,7 @@
   <string name="pref_transport_summary">투명프록시에 사용할 포트 (기본: 9040 / 0은 비활성화)</string>
   <string name="pref_transport_dialog">투명프록시 포트 설정</string>
   <string name="pref_dnsport_title">토르 DNS 포트</string>
-  <string name="pref_dnsport_summary">토르 DNS를 제공할 포트 (기본: 5400 / 0은 비활성화)</string>
+  <string name="pref_dnsport_summary">토르 DNS를 제공할 포트 (기본: 9053 / 0은 비활성화)</string>
   <string name="pref_dnsport_dialog">DNS 포트 설정</string>
   <string name="pref_torrc_title">사용자 지정 Torrc 구성</string>
   <string name="pref_torrc_summary">전문가 전용: torrc 구성 줄을 직접 입력합니다</string>

--- a/app-tv/src/main/res/values-lv/strings.xml
+++ b/app-tv/src/main/res/values-lv/strings.xml
@@ -97,7 +97,7 @@
   <string name="pref_transport_summary">Ports, uz kura Tor piedāvā savu Transparent starpniekserveri (noklusējumvērtība: 9040 vai 0 lai atspējotu)</string>
   <string name="pref_transport_dialog">TransProxy Port Config</string>
   <string name="pref_dnsport_title">Tor DNS Ports</string>
-  <string name="pref_dnsport_summary">Ports, uz kura Tor piedāvā savu DNS (noklusējumvērtība: 5400 vai 0 lai atspējotu)</string>
+  <string name="pref_dnsport_summary">Ports, uz kura Tor piedāvā savu DNS (noklusējumvērtība: 9053 vai 0 lai atspējotu)</string>
   <string name="pref_dnsport_dialog">DNS Port konfigurēšana</string>
   <string name="pref_torrc_title">Torrc pielāgota konfigurēšana</string>
   <string name="pref_torrc_summary">VIENĪGI EKSPERTIEM: tieši ievadīt torrc konfigurēšanas rindas</string>

--- a/app-tv/src/main/res/values-mk/strings.xml
+++ b/app-tv/src/main/res/values-mk/strings.xml
@@ -102,7 +102,7 @@
   <string name="pref_transport_summary">Порта на која Tor и го нуди својот транспарентен прокси (стандардно: 9040 или 0 за да се исклучи)</string>
   <string name="pref_transport_dialog">Поставување на портата за TransProxy</string>
   <string name="pref_dnsport_title">DNS-порта за Tor</string>
-  <string name="pref_dnsport_summary">Порта на која Tor го нуди својот DNS (стандардно: 5400 или 0 за да се исклучи)</string>
+  <string name="pref_dnsport_summary">Порта на која Tor го нуди својот DNS (стандардно: 9053 или 0 за да се исклучи)</string>
   <string name="pref_dnsport_dialog">Поставување на DNS-портата </string>
   <string name="pref_torrc_title">Прилагодено поставување на torrc</string>
   <string name="pref_torrc_summary">САМО ЗА ЕКСПЕРТИ: внесете директни команди за поставување на torrc</string>

--- a/app-tv/src/main/res/values-nb/strings.xml
+++ b/app-tv/src/main/res/values-nb/strings.xml
@@ -99,7 +99,7 @@
   <string name="pref_transport_summary">Porten Tor tilbyr transparent mellomtjening på (forvalg: 9040 eller 0 for å skru av)</string>
   <string name="pref_transport_dialog">Portoppsett for TransProxy</string>
   <string name="pref_dnsport_title">Tor DNS-port</string>
-  <string name="pref_dnsport_summary">Porten Tor tilbyr sin DNS-tjeneste på (forvalg: 5400 eller 0 for å skru av)</string>
+  <string name="pref_dnsport_summary">Porten Tor tilbyr sin DNS-tjeneste på (forvalg: 9053 eller 0 for å skru av)</string>
   <string name="pref_dnsport_dialog">DNS-portoppsett</string>
   <string name="pref_torrc_title">Egendefinert torrc-oppsett</string>
   <string name="pref_torrc_summary">BARE FOR EKSPERTER: skriv inn direkte torrc-oppsettslinjer</string>

--- a/app-tv/src/main/res/values-nl/strings.xml
+++ b/app-tv/src/main/res/values-nl/strings.xml
@@ -102,7 +102,7 @@
   <string name="pref_transport_summary">Poort waarop Tor de transparante proxy aanbiedt (standaard: 9040 of 0 om uit te schakelen)</string>
   <string name="pref_transport_dialog">TransProxy-poortconfiguratie</string>
   <string name="pref_dnsport_title">Tor DNS-poort</string>
-  <string name="pref_dnsport_summary">Poort waarop Tor de DNS aanbiedt (standaard: 5400 of 0 om uit te schakelen)</string>
+  <string name="pref_dnsport_summary">Poort waarop Tor de DNS aanbiedt (standaard: 9053 of 0 om uit te schakelen)</string>
   <string name="pref_dnsport_dialog">DNS-poortconfiguratie</string>
   <string name="pref_torrc_title">Torrc aangepaste configuratie</string>
   <string name="pref_torrc_summary">ENKEL VOOR GEVORDERDEN: voer rechtstreeks torrc-configuratieregels in</string>

--- a/app-tv/src/main/res/values-pl/strings.xml
+++ b/app-tv/src/main/res/values-pl/strings.xml
@@ -97,7 +97,7 @@
   <string name="pref_transport_summary">Port który oferuje Transparent Proxy (domyślnie: 9040 lub 0, aby wyłączyć)</string>
   <string name="pref_transport_dialog">Konfiguracja portu TransProxy</string>
   <string name="pref_dnsport_title">Tor DNS Port</string>
-  <string name="pref_dnsport_summary">Port na którym Tor oferuje swój DNS (domyślnie: 5400 lub 0, aby wyłączyć)</string>
+  <string name="pref_dnsport_summary">Port na którym Tor oferuje swój DNS (domyślnie: 9053 lub 0, aby wyłączyć)</string>
   <string name="pref_dnsport_dialog">Konfiguracja portu DNS</string>
   <string name="pref_torrc_title">Konfiguracja Torrc klienta</string>
   <string name="pref_torrc_summary">TYLKO DLA EKSPERTÓW: wpisz linijki konfiguracyjne torrc</string>

--- a/app-tv/src/main/res/values-pt-rBR/strings.xml
+++ b/app-tv/src/main/res/values-pt-rBR/strings.xml
@@ -102,7 +102,7 @@
   <string name="pref_transport_summary">Porta que Tor oferece seu Proxy Transparente no (padrão: 9040 ou 0 para desativar)</string>
   <string name="pref_transport_dialog">Config da Porta TransProxy</string>
   <string name="pref_dnsport_title">Porta DNS Tor</string>
-  <string name="pref_dnsport_summary">Porta que Tor oferece seu DNS no (padrão: 5400 ou 0 para desativar)</string>
+  <string name="pref_dnsport_summary">Porta que Tor oferece seu DNS no (padrão: 9053 ou 0 para desativar)</string>
   <string name="pref_dnsport_dialog">Config da Porta DNS</string>
   <string name="pref_torrc_title">Config Personalizada do Torrc</string>
   <string name="pref_torrc_summary">SOMENTE EXPERIENTES: adicione sua própria linha de configuração torrc</string>

--- a/app-tv/src/main/res/values-ro/strings.xml
+++ b/app-tv/src/main/res/values-ro/strings.xml
@@ -97,7 +97,7 @@
   <string name="pref_transport_summary">Porturi pe care Tor oferă Proxy-ul Transparent activ (principal:9040 sau 0 pentru dezactivare)</string>
   <string name="pref_transport_dialog">Portul Tor TransProxy </string>
   <string name="pref_dnsport_title">Portul DNS Tor</string>
-  <string name="pref_dnsport_summary">Porturi pe care Tor oferă DNS-ul activ (principal:5400 sau 0 pentru dezactivare)</string>
+  <string name="pref_dnsport_summary">Porturi pe care Tor oferă DNS-ul activ (principal:9053 sau 0 pentru dezactivare)</string>
   <string name="pref_dnsport_dialog">Configurare Port DNS</string>
   <string name="pref_torrc_title">Configurare personalizată Torrc</string>
   <string name="pref_torrc_summary">PENTRU EXPERŢI: introdu direct liniile de configurare ale torrc</string>

--- a/app-tv/src/main/res/values-ru/strings.xml
+++ b/app-tv/src/main/res/values-ru/strings.xml
@@ -102,7 +102,7 @@
   <string name="pref_transport_summary">Порт, на котором Tor предоставляет свой прозрачный прокси (по умолчанию: 9040, 0 - для отключения)</string>
   <string name="pref_transport_dialog">Настройка порта прозрачного прокси</string>
   <string name="pref_dnsport_title">Порт DNS Tor</string>
-  <string name="pref_dnsport_summary">Порт, на котором Tor предоставляет свой DNS (по умолчанию: 5400, 0 - для отключения)</string>
+  <string name="pref_dnsport_summary">Порт, на котором Tor предоставляет свой DNS (по умолчанию: 9053, 0 - для отключения)</string>
   <string name="pref_dnsport_dialog">Настройка порта DNS</string>
   <string name="pref_torrc_title">Пользовательские настройки Torrc</string>
   <string name="pref_torrc_summary">ТОЛЬКО ДЛЯ ЭКСПЕРТОВ: внесите настройки напрямую в строки файла конфигурации torrc</string>

--- a/app-tv/src/main/res/values-sk/strings.xml
+++ b/app-tv/src/main/res/values-sk/strings.xml
@@ -97,7 +97,7 @@
   <string name="pref_transport_summary">Port, na ktorom Tor poskytuje transparentné proxy (prednastavené 9040 alebo 0 pre deaktiváciu)</string>
   <string name="pref_transport_dialog">Nastavenia portu TransProxy</string>
   <string name="pref_dnsport_title">Tor DNS port</string>
-  <string name="pref_dnsport_summary">Port, na ktorom Tor poskytuje DNS (prednastavené 5400 alebo 0 pre deaktiváciu)</string>
+  <string name="pref_dnsport_summary">Port, na ktorom Tor poskytuje DNS (prednastavené 9053 alebo 0 pre deaktiváciu)</string>
   <string name="pref_dnsport_dialog">Nastavenie portu DNS</string>
   <string name="pref_torrc_title">Vlastné nastavenie Torrc</string>
   <string name="pref_torrc_summary">LEN PRE EXPERTOV: vložiť priamo riadky nastavenia torrc</string>

--- a/app-tv/src/main/res/values-sr/strings.xml
+++ b/app-tv/src/main/res/values-sr/strings.xml
@@ -100,7 +100,7 @@
   <string name="pref_transport_summary">Port који Тор нуди је Transparent Proxy укључен (уобичајено: 9040 или 0 за искључивање)</string>
   <string name="pref_transport_dialog">TransProxy Port Подешавања</string>
   <string name="pref_dnsport_title">Toр DNS Port</string>
-  <string name="pref_dnsport_summary">Port који Тор нуди је DNS укључен (уобичајено: 5400 или 0 за искључивање)</string>
+  <string name="pref_dnsport_summary">Port који Тор нуди је DNS укључен (уобичајено: 9053 или 0 за искључивање)</string>
   <string name="pref_dnsport_dialog">DNS Port Подешавања</string>
   <string name="pref_torrc_title">Torrc Прерађена Подешавања</string>
   <string name="pref_torrc_summary">САМО ЗА ЕКСПЕРТЕ: унети директно torrc линије подешавања</string>

--- a/app-tv/src/main/res/values-sv/strings.xml
+++ b/app-tv/src/main/res/values-sv/strings.xml
@@ -102,7 +102,7 @@
   <string name="pref_transport_summary">Port som Tor erbjuder sin transparenta proxy på (standard: 9040 eller 0 för att inaktivera)</string>
   <string name="pref_transport_dialog">TransProxy-port-inställningar</string>
   <string name="pref_dnsport_title">Tor DNS-port</string>
-  <string name="pref_dnsport_summary">Port som Tor erbjuder sin DNS på (standard: 5400 eller 0 för att inaktivera)</string>
+  <string name="pref_dnsport_summary">Port som Tor erbjuder sin DNS på (standard: 9053 eller 0 för att inaktivera)</string>
   <string name="pref_dnsport_dialog">DNS-port-inställningar</string>
   <string name="pref_torrc_title">Torrc anpassad konfiguration</string>
   <string name="pref_torrc_summary">ENDAST EXPERTER: ange torrc konfiguration direkt</string>

--- a/app-tv/src/main/res/values-th/strings.xml
+++ b/app-tv/src/main/res/values-th/strings.xml
@@ -102,7 +102,7 @@
   <string name="pref_transport_summary">พอร์ตที่ Tor ให้บริการพร็อกซีแบบ Transparent (ค่าเริ่มต้น: 9040 หรือ 0 ไปถึงไม่เปิดใช้งาน)</string>
   <string name="pref_transport_dialog">กำหนดค่าพอร์ตพร็อกซีแบบ Transparent</string>
   <string name="pref_dnsport_title">พอร์ต DNS ของ Tor</string>
-  <string name="pref_dnsport_summary">พอร์ตที่ Tor ให้บริการ DNS (ค่าเริ่มต้น: 5400 หรือ 0 ไปถึงไม่เปิดใช้งาน)</string>
+  <string name="pref_dnsport_summary">พอร์ตที่ Tor ให้บริการ DNS (ค่าเริ่มต้น: 9053 หรือ 0 ไปถึงไม่เปิดใช้งาน)</string>
   <string name="pref_dnsport_dialog">กำหนดค่าพอร์ต DNS</string>
   <string name="pref_torrc_title">กำหนดค่า Torrc เอง</string>
   <string name="pref_torrc_summary">สำหรับผู้เชี่ยวชาญเท่านั้น: ระบุบรรทัดที่กำหนดค่า torcc โดยตรง</string>

--- a/app-tv/src/main/res/values-tr/strings.xml
+++ b/app-tv/src/main/res/values-tr/strings.xml
@@ -102,7 +102,7 @@
   <string name="pref_transport_summary">Tor saydam vekil sunucusu için kullanılacak kapı numarası (Varsayılan 9040 ya da devre dışı bırakmak için 0)</string>
   <string name="pref_transport_dialog">Aktarım Vekil Sunucusu Kapı Numarası Ayarı</string>
   <string name="pref_dnsport_title">Tor DNS Kapı Numarası</string>
-  <string name="pref_dnsport_summary">Tor DNS hizmeti için kullanılacak kapı numarası (Varsayılan 5400 ya da devre dışı bırakmak için 0)</string>
+  <string name="pref_dnsport_summary">Tor DNS hizmeti için kullanılacak kapı numarası (Varsayılan 9053 ya da devre dışı bırakmak için 0)</string>
   <string name="pref_dnsport_dialog">DNS Kapı Numarası Ayarı</string>
   <string name="pref_torrc_title">Özel Torrc Ayarları</string>
   <string name="pref_torrc_summary">UZMANLAR İÇİN: torrc ayar satırlarını doğrudan yazın</string>

--- a/app-tv/src/main/res/values-uk/strings.xml
+++ b/app-tv/src/main/res/values-uk/strings.xml
@@ -102,7 +102,7 @@
   <string name="pref_transport_summary">Порт, який Tor надає своєму відкритому проксі (за замовчуванням: 9040 або 0 для вимкнення)</string>
   <string name="pref_transport_dialog">Налаштування порту Tor TransProxy</string>
   <string name="pref_dnsport_title">Порт Tor DNS</string>
-  <string name="pref_dnsport_summary">Порт, який Tor надає своєму DNS (за замовчуванням: 5400 або 0 для вимкнення)</string>
+  <string name="pref_dnsport_summary">Порт, який Tor надає своєму DNS (за замовчуванням: 9053 або 0 для вимкнення)</string>
   <string name="pref_dnsport_dialog">Налаштування порту DNS</string>
   <string name="pref_torrc_title">Додаткові налаштування Torrc</string>
   <string name="pref_torrc_summary">ЛИШЕ ДЛЯ ЕКСПЕРТІВ: введіть безпосередні рядки налаштувань torrc</string>

--- a/app-tv/src/main/res/values-vi/strings.xml
+++ b/app-tv/src/main/res/values-vi/strings.xml
@@ -97,7 +97,7 @@
   <string name="pref_transport_summary">Cổng để Tor đặt proxy trong suốt lên (mặc định: 9040 hoặc 0 để vô hiệu hóa)</string>
   <string name="pref_transport_dialog">Cấu hình cổng proxy trong suốt</string>
   <string name="pref_dnsport_title">Cổng DNS Tor</string>
-  <string name="pref_dnsport_summary">Cổng để Tor đặt DNS của nó lên (mặc định: 5400 hoặc 0 để vô hiệu hóa)</string>
+  <string name="pref_dnsport_summary">Cổng để Tor đặt DNS của nó lên (mặc định: 9053 hoặc 0 để vô hiệu hóa)</string>
   <string name="pref_dnsport_dialog">Cấu hình cổng DNS</string>
   <string name="pref_torrc_title">Cấu hình tùy chỉnh cho Torrc</string>
   <string name="pref_torrc_summary">CHỈ NGƯỜI DÙNG CHUYÊN MÔN: nhập các thiết lập trực tiếp cho torrc</string>

--- a/app-tv/src/main/res/values-zh-rCN/strings.xml
+++ b/app-tv/src/main/res/values-zh-rCN/strings.xml
@@ -97,7 +97,7 @@
   <string name="pref_transport_summary">Tor 提供透明代理的端口 (默认: 9040, 0 禁用)</string>
   <string name="pref_transport_dialog">透明代理配置</string>
   <string name="pref_dnsport_title">Tor DNS 端口</string>
-  <string name="pref_dnsport_summary">Tor 提供 DNS 的端口 (默认: 5400, 0 禁用)</string>
+  <string name="pref_dnsport_summary">Tor 提供 DNS 的端口 (默认: 9053, 0 禁用)</string>
   <string name="pref_dnsport_dialog">DNS 端口配置</string>
   <string name="pref_torrc_title">Torrc 自定义配置</string>
   <string name="pref_torrc_summary">仅供专家：直接输入 torrc 配置行</string>

--- a/app-tv/src/main/res/values-zh-rTW/strings.xml
+++ b/app-tv/src/main/res/values-zh-rTW/strings.xml
@@ -102,7 +102,7 @@
   <string name="pref_transport_summary">Tor 提供通透式代理的連接埠 (預設：9040，若設為 0 則關閉)</string>
   <string name="pref_transport_dialog">設定通透式代理連接埠</string>
   <string name="pref_dnsport_title">Tor DNS 埠</string>
-  <string name="pref_dnsport_summary">Tor 提供域名解析服務（DNS）的連接埠 (預設：5400，若設為0則關閉)</string>
+  <string name="pref_dnsport_summary">Tor 提供域名解析服務（DNS）的連接埠 (預設：9053，若設為0則關閉)</string>
   <string name="pref_dnsport_dialog">DNS連接埠設定</string>
   <string name="pref_torrc_title">Torrc 自訂設置</string>
   <string name="pref_torrc_summary">僅限專家：輸入 torrc 設定指令</string>

--- a/app-tv/src/main/res/values/strings.xml
+++ b/app-tv/src/main/res/values/strings.xml
@@ -123,7 +123,7 @@
 
 
     <string name="pref_dnsport_title">Tor DNS Port</string>
-    <string name="pref_dnsport_summary">Port that Tor offers its DNS on (default: 5400 or 0 to disable)</string>
+    <string name="pref_dnsport_summary">Port that Tor offers its DNS on (default: 9053 or 0 to disable)</string>
     <string name="pref_dnsport_dialog">DNS Port Config</string>
 
 

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -86,7 +86,7 @@
     <string name="pref_transport_summary">منفذ الشبكات الحاسوبية الذي يقدمه تور إلى البروكسي الشفاف (المنفذ 9040 او 0 عدم القدرة)</string>
     <string name="pref_transport_dialog">تهيئة منفذ البروكسي الشفاف</string>
     <string name="pref_dnsport_title">منفذ الشبكات الحاسوبية لنظام أسماء النطاقات الخاص ب تور</string>
-    <string name="pref_dnsport_summary">منفذ الشبكات الحاسوبية او بورت الذي يقدمه تور الى خدمة اسماء النطاق دي ان اس. (التقصير 5400 او 0 لعدم القدرة)</string>
+    <string name="pref_dnsport_summary">منفذ الشبكات الحاسوبية او بورت الذي يقدمه تور الى خدمة اسماء النطاق دي ان اس. (التقصير 9053 او 0 لعدم القدرة)</string>
     <string name="pref_dnsport_dialog">إعدادات بورت خادم اسماء النطاق</string>
     <string name="pref_torrc_title">ترتيبات خاصة بـ torrc</string>
     <string name="pref_torrc_summary">للخبراء فقط : أدخل أسطر ملف torrc مباشرةً</string>

--- a/app/src/main/res/values-ay/strings.xml
+++ b/app/src/main/res/values-ay/strings.xml
@@ -89,7 +89,7 @@
     <string name="pref_transport_summary">Waythapiwja kawkïrxaruti Torax Qhana proxyp churañ muni (utt\'ata: jiwt\'ayañatakix 9040 jan ukax 0)</string>
     <string name="pref_transport_dialog">TransProxy waythapiwj mayjt\'ayaña</string>
     <string name="pref_dnsport_title">Tor DNS waythapiwja</string>
-    <string name="pref_dnsport_summary">Waythapiwja kawkïrxaruti Torax DNS ukap churañ muni: (utt\'ata: jiwt\'ayañatakix 5400 jan ukax 0)</string>
+    <string name="pref_dnsport_summary">Waythapiwja kawkïrxaruti Torax DNS ukap churañ muni: (utt\'ata: jiwt\'ayañatakix 9053 jan ukax 0)</string>
     <string name="pref_dnsport_dialog">DNS waythapiwj mayjt\'ayaña</string>
     <string name="pref_torrc_title">Torrc mayjt\'ayaña</string>
     <string name="pref_torrc_summary">YATIRINAKATAKIKI: torrc apthapitan chiqak mayjt\'ayam</string>

--- a/app/src/main/res/values-az/strings.xml
+++ b/app/src/main/res/values-az/strings.xml
@@ -86,7 +86,7 @@
     <string name="pref_transport_summary">Torun təklif etdiyi Port Transparent proksi işləyir (standart: 9040, yaxud söndürmək üçün 0) </string>
     <string name="pref_transport_dialog">TransProxy Port Konfiqurasiyası</string>
     <string name="pref_dnsport_title">Tor DNS Port</string>
-    <string name="pref_dnsport_summary">Torun təklif etdiyi Port DNS işləyir (standart: 5400, yaxud söndürmək üçün 0)</string>
+    <string name="pref_dnsport_summary">Torun təklif etdiyi Port DNS işləyir (standart: 9053, yaxud söndürmək üçün 0)</string>
     <string name="pref_dnsport_dialog">DNS Port Konfiqurasiyası</string>
     <string name="pref_torrc_title">Torrc Xüsusi Konfiqurasiya</string>
     <string name="pref_torrc_summary">YALNIZ EKSPERTLƏR: birbaşa torrc config xətlərini daxil edin</string>

--- a/app/src/main/res/values-be/strings.xml
+++ b/app/src/main/res/values-be/strings.xml
@@ -88,7 +88,7 @@
     <string name="pref_transport_summary">Порт, на якім Tor прапануе свой празрысты проксі (па змаўчанні: 9040, 0 - для адключэння)</string>
     <string name="pref_transport_dialog">Налада порта празрыстага проксі</string>
     <string name="pref_dnsport_title">Порт DNS Tor</string>
-    <string name="pref_dnsport_summary">Порт, на якім Tor прапануе свой DNS (па змаўчанні: 5400, 0 - для адключэння)</string>
+    <string name="pref_dnsport_summary">Порт, на якім Tor прапануе свой DNS (па змаўчанні: 9053, 0 - для адключэння)</string>
     <string name="pref_dnsport_dialog">Налада порта DNS</string>
     <string name="pref_torrc_title">Карыстальніцкія налады Torrc</string>
     <string name="pref_torrc_summary">ТОЛЬКІ ДЛЯ ЭКСПЕРТАЎ: унясіце налады наўпрост у радкі файла канфігурацыі torrc</string>

--- a/app/src/main/res/values-bg/strings.xml
+++ b/app/src/main/res/values-bg/strings.xml
@@ -86,7 +86,7 @@
     <string name="pref_transport_summary">Порт, на който Тор предлага прозрачен сървър за прокси (подразбиран: 9040 или 0 за изключване)</string>
     <string name="pref_transport_dialog">Настройка на порта на прозрачен сървър за прокси</string>
     <string name="pref_dnsport_title">Порт за DNS на Тор</string>
-    <string name="pref_dnsport_summary">Порт, на който Тор предлага услуга за DNS (подразбиран: 5400 или 0 за изключване)</string>
+    <string name="pref_dnsport_summary">Порт, на който Тор предлага услуга за DNS (подразбиран: 9053 или 0 за изключване)</string>
     <string name="pref_dnsport_dialog">Настройка на порта за DNS</string>
     <string name="pref_torrc_title">Потребителски настройки на Torrc</string>
     <string name="pref_torrc_summary">ЗА ЕКСПЕРТИ: въведете редовете с настройки за torrc</string>

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -88,7 +88,7 @@
     <string name="pref_transport_summary">Port al qual el Tor ofereix el seu servidor intermediari Transparent (per defecte: 9040, o 0 per a desactivar)</string>
     <string name="pref_transport_dialog">Configuració del port TransProxy</string>
     <string name="pref_dnsport_title">Port DNS del Tor</string>
-    <string name="pref_dnsport_summary">Port al qual el Tor ofereix el seu DNS (per defecte: 5400, o 0 per a desactivar)</string>
+    <string name="pref_dnsport_summary">Port al qual el Tor ofereix el seu DNS (per defecte: 9053, o 0 per a desactivar)</string>
     <string name="pref_dnsport_dialog">Configuració del port DNS</string>
     <string name="pref_torrc_title">Configuració personalitzada del Torrc</string>
     <string name="pref_torrc_summary">NOMÉS EXPERTS: Escriviu línies de configuració directes del Torrc</string>

--- a/app/src/main/res/values-cs-rCZ/strings.xml
+++ b/app/src/main/res/values-cs-rCZ/strings.xml
@@ -86,7 +86,7 @@
     <string name="pref_transport_summary">Port, na kterém Tor nabízí transparentní proxy (default: 9040, 0 pro zakázání)</string>
     <string name="pref_transport_dialog">TransProxy nastavení portu</string>
     <string name="pref_dnsport_title">Tor DNS port</string>
-    <string name="pref_dnsport_summary">Port, na kterém Tor nabízí DNS (default: 5400, 0 pro zakázání)</string>
+    <string name="pref_dnsport_summary">Port, na kterém Tor nabízí DNS (default: 9053, 0 pro zakázání)</string>
     <string name="pref_dnsport_dialog">DNS nastavení portu</string>
     <string name="pref_torrc_title">Torrc vstastní konfigurace</string>
     <string name="pref_torrc_summary">POUZE PRO EXPERTY: zadejte přímo řádky nastavení torrc</string>

--- a/app/src/main/res/values-cy/strings.xml
+++ b/app/src/main/res/values-cy/strings.xml
@@ -117,7 +117,7 @@
     <string name="bridge_community">Cysylltwch trwy weinyddion cymunedol</string>
     <string name="bridge_cloud">Cysylltwch trwy weinyddion cwmwl</string>
     <string name="pref_circuit_padding">Padin cylched</string>
-    <string name="pref_dnsport_summary">Porthladd y mae Tor yn cynnig ei DNS arno (rhagosodedig: 5400 neu 0 i\'w analluogi)</string>
+    <string name="pref_dnsport_summary">Porthladd y mae Tor yn cynnig ei DNS arno (rhagosodedig: 9053 neu 0 i\'w analluogi)</string>
     <string name="pref_isolate_dest_summary">Defnyddiwch gylched wahanol ar gyfer pob cyfeiriad cyrchfan</string>
     <string name="v3_hosted_services">Gwasanaethau Winwns a Gynhelir</string>
     <string name="msg_try_something_else">Rhowch gynnig ar rywbeth arall</string>

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -83,7 +83,7 @@
     <string name="consider_disable_battery_optimizations">Hostede tjenester kører, overvej at deaktivere batterioptimeringer</string>
     <string name="v3_delete_client_authorization_confirm">Slet klienttilladelse</string>
     <string name="v3_backup_name_hint">Backup filnavn…</string>
-    <string name="pref_dnsport_summary">Port, som Tor tilbyder sin DNS på (standard: 5400 eller 0 for at deaktivere)</string>
+    <string name="pref_dnsport_summary">Port, som Tor tilbyder sin DNS på (standard: 9053 eller 0 for at deaktivere)</string>
     <string name="pref_torrc_title">Torrc brugerdefineret konfiguration</string>
     <string name="kibibyte">KiB</string>
     <string name="v3_onion">.onion-domæne</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -88,7 +88,7 @@
     <string name="pref_transport_summary">Port, der den transparenten Proxy von Tor bereitstellt (Standard: 9040 oder 0, um ihn zu deaktivieren)</string>
     <string name="pref_transport_dialog">TransProxy-Port-Konfiguration</string>
     <string name="pref_dnsport_title">Tor-DNS-Port</string>
-    <string name="pref_dnsport_summary">Port, an dem Tor seinen DNS bereitstellt (Standard: 5400 oder 0, um ihn zu deaktivieren)</string>
+    <string name="pref_dnsport_summary">Port, an dem Tor seinen DNS bereitstellt (Standard: 9053 oder 0, um ihn zu deaktivieren)</string>
     <string name="pref_dnsport_dialog">DNS-Port-Konfiguration</string>
     <string name="pref_torrc_title">Benutzerdefinierte Torrc-Konfiguration</string>
     <string name="pref_torrc_summary">NUR FÜR EXPERTEN: torrc-Konfigurationszeilen direkt eingeben</string>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -88,7 +88,7 @@
     <string name="pref_transport_summary">Θύρα που προσφέρει ο Tor στον Transparent Proxy του (προεπιλογή: 9040 ή 0 για απενεργοποίηση)</string>
     <string name="pref_transport_dialog">Διάρθρωση Θύρας TransProxy</string>
     <string name="pref_dnsport_title">Tor Θύρα DNS </string>
-    <string name="pref_dnsport_summary">Θύρα που προσφέρει ο Tor στο DNS του (προεπιλογή: 5400 ή 0 για απενεργοποίηση)</string>
+    <string name="pref_dnsport_summary">Θύρα που προσφέρει ο Tor στο DNS του (προεπιλογή: 9053 ή 0 για απενεργοποίηση)</string>
     <string name="pref_dnsport_dialog">Διάρθρωση Θύρας DNS</string>
     <string name="pref_torrc_title">Προσαρμοσμένη διαμόρφωση Torrc</string>
     <string name="pref_torrc_summary">ΜΟΝΟ ΓΙΑ ΕΙΔΙΚΟΥΣ: πληκτρολογήστε απευθείας torrc config γραμμές</string>

--- a/app/src/main/res/values-en-rGB/strings.xml
+++ b/app/src/main/res/values-en-rGB/strings.xml
@@ -187,7 +187,7 @@
     <string name="pref_socks_title">Tor SOCKS</string>
     <string name="pref_socks_dialog">SOCKS Port Config</string>
     <string name="pref_http_title">Tor HTTP</string>
-    <string name="pref_dnsport_summary">Port that Tor offers its DNS on (default: 5400 or 0 to disable)</string>
+    <string name="pref_dnsport_summary">Port that Tor offers its DNS on (default: 9053 or 0 to disable)</string>
     <string name="pref_torrc_title">Torrc Custom Config</string>
     <string name="kibibyte">KiB</string>
     <string name="restart_orbot_to_use_this_bridge_">Please restart Orbot to enable the changes</string>

--- a/app/src/main/res/values-es-rCU/strings.xml
+++ b/app/src/main/res/values-es-rCU/strings.xml
@@ -91,7 +91,7 @@
     <string name="action_activate">Activar</string>
     <string name="apps_other_apps">Otras aplicaciones</string>
     <string name="pref_dnsport_title">Puerto DNS de Tor</string>
-    <string name="pref_dnsport_summary">Puerto por el cual Tor ofrece su conexión DNS (por defecto: 5400 o 0 para inhabilitar)</string>
+    <string name="pref_dnsport_summary">Puerto por el cual Tor ofrece su conexión DNS (por defecto: 9053 o 0 para inhabilitar)</string>
     <string name="pref_dnsport_dialog">Configuración del puerto DNS</string>
     <string name="pref_disable_network_summary">Desactivar Tor cuando no hay internet disponible</string>
     <string name="newnym">¡Has cambiado a una nueva identidad Tor!</string>

--- a/app/src/main/res/values-es-rES/strings.xml
+++ b/app/src/main/res/values-es-rES/strings.xml
@@ -88,7 +88,7 @@
     <string name="pref_transport_summary">Puerto sobre el que Tor ofrece tu Proxy Transparente (por defecto: 9040 o 0 para deshabilitarlo)</string>
     <string name="pref_transport_dialog">Configuración del puerto de TransProxy</string>
     <string name="pref_dnsport_title">Puerto DNS de Tor</string>
-    <string name="pref_dnsport_summary">Puerto sobre el que Tor ofrece su DNS (por defecto: 5400 o 0 para deshabilitarlo)</string>
+    <string name="pref_dnsport_summary">Puerto sobre el que Tor ofrece su DNS (por defecto: 9053 o 0 para deshabilitarlo)</string>
     <string name="pref_dnsport_dialog">Configuración del puerto DNS</string>
     <string name="pref_torrc_title">Configuración personalizada de Torrc</string>
     <string name="pref_torrc_summary">SÓLO EXPERTOS: Introduce directamente las líneas de configuración en el fichero torrc</string>

--- a/app/src/main/res/values-es-rMX/strings.xml
+++ b/app/src/main/res/values-es-rMX/strings.xml
@@ -56,7 +56,7 @@
     <string name="pref_transport_dialog">Configuración del puerto TransProxy</string>
     <string name="pref_http_summary">Puerto en el que Tor ofrece tu proxy HTTP (predeterminado: 8118 o 0 para deshabilitar)</string>
     <string name="pref_transport_title">Puerto Tor TransProxy</string>
-    <string name="pref_dnsport_summary">Puerto en el que Tor ofrece tu DNS (predeterminado: 5400 o 0 para deshabilitar)</string>
+    <string name="pref_dnsport_summary">Puerto en el que Tor ofrece tu DNS (predeterminado: 9053 o 0 para deshabilitar)</string>
     <string name="get_bridges_email">Correo Electronico</string>
     <string name="pref_isolate_dest">Aislar direcciones de destino</string>
     <string name="pref_torrc_title">Configuración personalizada Torrc</string>

--- a/app/src/main/res/values-et/strings.xml
+++ b/app/src/main/res/values-et/strings.xml
@@ -149,7 +149,7 @@
     <string name="pref_http_title">Tori HTTP</string>
     <string name="pref_transport_summary">Port, millel Tor pakub oma läbipaistvat proksi (vaikimisi: 9040 või 0, et keelata)</string>
     <string name="pref_dnsport_title">Tor DNS-port</string>
-    <string name="pref_dnsport_summary">Port, millel Tor pakub oma DNS-i (vaikimisi: 5400 või 0, et keelata)</string>
+    <string name="pref_dnsport_summary">Port, millel Tor pakub oma DNS-i (vaikimisi: 9053 või 0, et keelata)</string>
     <string name="pref_torrc_title">Torrc kohandatud konfiguratsioon</string>
     <string name="mebibyte">MiB</string>
     <string name="bridges_updated">Ajakohastatud sillad</string>

--- a/app/src/main/res/values-eu/strings.xml
+++ b/app/src/main/res/values-eu/strings.xml
@@ -88,7 +88,7 @@
     <string name="pref_transport_summary">Tor-ek bere Proxy gardena eskaintzeko ataka (Lehenetsia: 9040 edo 0 desgaitzeko)</string>
     <string name="pref_transport_dialog">Proxy gardenaren atakaren konfigurazioa</string>
     <string name="pref_dnsport_title">Tor DNS ataka</string>
-    <string name="pref_dnsport_summary">Tor-ek bere DNS-a eskaintzeko ataka (Lehenetsia: 5400 edo 0 desgaitzeko)</string>
+    <string name="pref_dnsport_summary">Tor-ek bere DNS-a eskaintzeko ataka (Lehenetsia: 9053 edo 0 desgaitzeko)</string>
     <string name="pref_dnsport_dialog">DNS atakaren konfigurazioa</string>
     <string name="pref_torrc_title">Torrc konfigurazio pertsonala</string>
     <string name="pref_torrc_summary">ADITUAK BESTERIK EZ: sartu torrc konfigurazio lerroak</string>

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -86,7 +86,7 @@
     <string name="pref_transport_summary">Portti, jonka kautta Torin lähinäkyvä välityspalvelin on tavoitettavissa (oletus on 9040 tai pois käytöstä arvolla 0).</string>
     <string name="pref_transport_dialog">Syötä TransProxy-porttimääritys</string>
     <string name="pref_dnsport_title">Tor DNS-portti</string>
-    <string name="pref_dnsport_summary">Portti, jonka Torin DNS on tavoitettavissa (oletus on 5400 tai pois käytöstä arvolla 0).</string>
+    <string name="pref_dnsport_summary">Portti, jonka Torin DNS on tavoitettavissa (oletus on 9053 tai pois käytöstä arvolla 0).</string>
     <string name="pref_dnsport_dialog">Syötä DNS-porttimääritys</string>
     <string name="pref_torrc_title">Omat Torrc-määritykset</string>
     <string name="pref_torrc_summary">VAIN KOKENEILLE KÄYTTÄJILLE: Syötä Torrc-määritysrivejä suoraan.</string>

--- a/app/src/main/res/values-fr-rFR/strings.xml
+++ b/app/src/main/res/values-fr-rFR/strings.xml
@@ -78,7 +78,7 @@
     <string name="pref_transport_summary">Port sur lequel Tor offre son mandataire transparent (par défaut : 9040 ou 0 pour le désactiver)</string>
     <string name="pref_transport_dialog">Configuration du port du mandataire transparent</string>
     <string name="pref_dnsport_title">Port DNS de Tor</string>
-    <string name="pref_dnsport_summary">Port sur lequel Tor offre son DNS (par défaut : 5400 ou 0 pour le désactiver)</string>
+    <string name="pref_dnsport_summary">Port sur lequel Tor offre son DNS (par défaut : 9053 ou 0 pour le désactiver)</string>
     <string name="pref_dnsport_dialog">Configuration du port DNS</string>
     <string name="pref_torrc_title">Configuration personnalisée de Torrc</string>
     <string name="pref_torrc_summary">EXPERTS SEULEMENT : saisissez les lignes de configuration directe de torrc</string>

--- a/app/src/main/res/values-gl/strings.xml
+++ b/app/src/main/res/values-gl/strings.xml
@@ -88,7 +88,7 @@
     <string name="pref_transport_summary">Porto no que Tor proporciona o Proxy Transparente (por omisión: 9040 ou 0 para desactivar)</string>
     <string name="pref_transport_dialog">Axuste do porto TransProxy</string>
     <string name="pref_dnsport_title">Porto DNS de Tor</string>
-    <string name="pref_dnsport_summary">Porto no que Tor ofrece o seu DNS (por omisión: 5400 ou 0 para desactivar)</string>
+    <string name="pref_dnsport_summary">Porto no que Tor ofrece o seu DNS (por omisión: 9053 ou 0 para desactivar)</string>
     <string name="pref_dnsport_dialog">Axuste do porto DNS</string>
     <string name="pref_torrc_title">Axuste Torrc personalizado</string>
     <string name="pref_torrc_summary">SO PARA EXPERTAS: introducir liñas de configuración directa torrc</string>

--- a/app/src/main/res/values-guc/strings.xml
+++ b/app/src/main/res/values-guc/strings.xml
@@ -90,7 +90,7 @@
   <string name="pref_transport_summary">Juntia jupüla Tor japu\'in Proxy  ( default: 9040 or to  disable)</string>
   <string name="pref_transport_dialog">anatia juntia  Proxy </string>
   <string name="pref_dnsport_title">Juntia DNS TOR</string>
-  <string name="pref_dnsport_summary">Juntia numanaa tor apushi DNS (Default : 5400 or  to disable )</string>
+  <string name="pref_dnsport_summary">Juntia numanaa tor apushi DNS (Default : 9053 or  to disable )</string>
   <string name="pref_dnsport_dialog">DNS Anatia Juntia. </string>
   <string name="pref_torrc_title">Anatia pupula torr c</string>
   <string name="pref_torrc_summary">Jupula na a\'tujushanaka  jikerrolo julu Torrc</string>

--- a/app/src/main/res/values-gum/strings.xml
+++ b/app/src/main/res/values-gum/strings.xml
@@ -92,7 +92,7 @@
   <string name="pref_transport_summary">Toryu kepiamik transparente teik wam pirishipik teik (srɵ kutri tamara pasrikpe: 9040 kape 0 trek tamarikwan yunɵmaramik)</string>
   <string name="pref_transport_dialog">TransProxy Kepampamtik srɵlmeran tamaramik</string>
   <string name="pref_dnsport_title"> Tor DNS kepampamtik srɵl</string>
-  <string name="pref_dnsport_summary">Toryu kepiamik  wam pirishipik DNS teik (srɵ kutri tamara pasrikpe: 5400 kape 0 trek tamarikwan yunɵmaramik)</string>
+  <string name="pref_dnsport_summary">Toryu kepiamik  wam pirishipik DNS teik (srɵ kutri tamara pasrikpe: 9053 kape 0 trek tamarikwan yunɵmaramik)</string>
   <string name="pref_dnsport_dialog">Puerto DNSmeran Tamaramik</string>
   <string name="pref_torrc_title">Torrcwan na asikmei tamara pasramik</string>
   <string name="pref_torrc_summary">IKWANE TSAPɵ ASHIPELɵTɵ MARAMIK: kan meitɵ torrc tamaramik srɵlmeran ker</string>

--- a/app/src/main/res/values-hi/strings.xml
+++ b/app/src/main/res/values-hi/strings.xml
@@ -88,7 +88,7 @@
     <string name="pref_transport_summary">वो पोर्ट जिसपे टॉर अपनी ट्रांस्पैरंट प्रॉक्सी देत है (डिफॉल्ट: 9040 या 0 बंद करने के लिए)</string>
     <string name="pref_transport_dialog">ट्रांसप्रॉक्सी पोर्ट सेटिंग</string>
     <string name="pref_dnsport_title">टॉर डीएनएस पोर्ट</string>
-    <string name="pref_dnsport_summary">वो पोर्ट जिसपे टॉर अपना डीएनएस देता है (डिफॉल्ट: 5400 या 0 बंद करने के लिए)</string>
+    <string name="pref_dnsport_summary">वो पोर्ट जिसपे टॉर अपना डीएनएस देता है (डिफॉल्ट: 9053 या 0 बंद करने के लिए)</string>
     <string name="pref_dnsport_dialog">डीएनएस पोर्ट सेटिंग</string>
     <string name="pref_torrc_title">टॉर्रक कस्टम सेटिंग</string>
     <string name="pref_torrc_summary">सिर्फ एक्सपर्ट के लिए: डायरेक्ट टॉर्रक सेटिंग लाइनें डालें</string>

--- a/app/src/main/res/values-hr-rHR/strings.xml
+++ b/app/src/main/res/values-hr-rHR/strings.xml
@@ -86,7 +86,7 @@
     <string name="pref_transport_summary">Port na kojem Tor pruža Transparentni Proxy (zadano: 9040, 0 za onemogućivanje)</string>
     <string name="pref_transport_dialog">Konfiguracija TransProxy porta</string>
     <string name="pref_dnsport_title">Tor DNS Port</string>
-    <string name="pref_dnsport_summary">Port na kojem Tor pruža DNS (zadano 5400, 0 za onemogućivanje)</string>
+    <string name="pref_dnsport_summary">Port na kojem Tor pruža DNS (zadano 9053, 0 za onemogućivanje)</string>
     <string name="pref_dnsport_dialog">Postavljanje DNS porta</string>
     <string name="pref_torrc_title">Torrc prilagođena konfiguracija</string>
     <string name="pref_torrc_summary">SAMO ZA STRUČNJAKE: unesite direktno torrc konfiguracijske linije</string>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -88,7 +88,7 @@
     <string name="pref_transport_summary">Port, amelyen a Tor a transzparens proxyt ajánl (alapértelmezett: 9040 vagy 0 a tiltáshoz)</string>
     <string name="pref_transport_dialog">TransProxy port konfiguráció</string>
     <string name="pref_dnsport_title">Tor DNS port</string>
-    <string name="pref_dnsport_summary">Port, amelyen a Tor a saját DNS-t ajánlja (alapértelmezett: 5400 vagy 0 a letiltáshoz)</string>
+    <string name="pref_dnsport_summary">Port, amelyen a Tor a saját DNS-t ajánlja (alapértelmezett: 9053 vagy 0 a letiltáshoz)</string>
     <string name="pref_dnsport_dialog">DNS port konfiguráció</string>
     <string name="pref_torrc_title">Torrc egyedi konfiguráció</string>
     <string name="pref_torrc_summary">CSAK SZAKÉRTŐKNEK: torrc konfigurációs sorok közvetlen beírása</string>

--- a/app/src/main/res/values-hy-rAM/strings.xml
+++ b/app/src/main/res/values-hy-rAM/strings.xml
@@ -148,7 +148,7 @@
     <string name="pref_socks_title">Tor SOCKS</string>
     <string name="pref_http_title">Tor HTTP</string>
     <string name="pref_dnsport_title">Tor DNS մատույց</string>
-    <string name="pref_dnsport_summary">Մատույցը, որով Tor-ն առաջարկում է իր «DNS»-ը (լռելայնը՝ 5400 կամ 0՝ կարողազրկման համար)</string>
+    <string name="pref_dnsport_summary">Մատույցը, որով Tor-ն առաջարկում է իր «DNS»-ը (լռելայնը՝ 9053 կամ 0՝ կարողազրկման համար)</string>
     <string name="local_port">Տեղական մատույց</string>
     <string name="please_restart_Orbot_to_enable_the_changes">Փոփոխությունների կատարման համար խնդրում ենք վերսկսել «Orbot»-ը</string>
     <string name="pref_prefer_ipv6">Նախընտել IPv6 միացումները</string>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -86,7 +86,7 @@
     <string name="pref_transport_summary">Port tempat Proxy Transparan Tor aktif (standar: 9040 atau 0 untuk mematikan)</string>
     <string name="pref_transport_dialog">Konfigurasi Port TransProxy</string>
     <string name="pref_dnsport_title">Port DNS Tor</string>
-    <string name="pref_dnsport_summary">Port tempat DNS Tor aktif (standar: 5400 atau 0 untuk mematikan)</string>
+    <string name="pref_dnsport_summary">Port tempat DNS Tor aktif (standar: 9053 atau 0 untuk mematikan)</string>
     <string name="pref_dnsport_dialog">Konfigurasi Port DNS</string>
     <string name="pref_torrc_title">Konfigurasi Torrc</string>
     <string name="pref_torrc_summary">HANYA UNTUK AHLI: masukkan baris konfigurasi direct Torrc</string>

--- a/app/src/main/res/values-is/strings.xml
+++ b/app/src/main/res/values-is/strings.xml
@@ -88,7 +88,7 @@
     <string name="pref_transport_summary">Gátt sem Tor býður gegnsæja milliþjónsbeiningu á (sjálfgefið: 9040 eða 0 til að gera óvirkt)</string>
     <string name="pref_transport_dialog">Uppsetning gáttar fyrir gegnsæja milliþjónabeiningu (TransProxy)</string>
     <string name="pref_dnsport_title">Tor DNS-gátt</string>
-    <string name="pref_dnsport_summary">Gátt sem Tor býður DNS á (sjálfgefið: 5400 eða 0 til að gera óvirkt)</string>
+    <string name="pref_dnsport_summary">Gátt sem Tor býður DNS á (sjálfgefið: 9053 eða 0 til að gera óvirkt)</string>
     <string name="pref_dnsport_dialog">Stilling á DNS-gátt</string>
     <string name="pref_torrc_title">Sérsniðnar stillingar Torrc</string>
     <string name="pref_torrc_summary">AÐEINS SÉRFRÆÐINGAR: sláðu inn stillingarlínur beint í torrc</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -88,7 +88,7 @@
     <string name="pref_transport_summary">Porta su cui Tor offre il proxy trasparente (predefinita: 9040 o 0 per disattivare)</string>
     <string name="pref_transport_dialog">Configurazione porta TransProxy</string>
     <string name="pref_dnsport_title">Porte Tor DNS</string>
-    <string name="pref_dnsport_summary">Porta su cui Tor offre i suoi DNS (predefinita: 5400 o 0 per disattivare)</string>
+    <string name="pref_dnsport_summary">Porta su cui Tor offre i suoi DNS (predefinita: 9053 o 0 per disattivare)</string>
     <string name="pref_dnsport_dialog">Configurazione porte DNS</string>
     <string name="pref_torrc_title">Configurazione personalizzata di Torrc</string>
     <string name="pref_torrc_summary">SOLO ESPERTI: inserisci direttamente le righe per torrc</string>

--- a/app/src/main/res/values-iw/strings.xml
+++ b/app/src/main/res/values-iw/strings.xml
@@ -97,7 +97,7 @@
     <string name="pref_open_proxy_on_all_interfaces_title">פתיחת מתווך על כל המנשקים</string>
     <string name="pref_open_proxy_on_all_interfaces_summary">לאפשר לעמיתים ברשת האלחוטית, מכשירים קשורים ולכל מי שיכול להתחבר ל־IP שלך לגשת לתור</string>
     <string name="pref_socks_summary">פתחה אשר תור מציע את מתווך ה־SOCKS שלו עליה (ברירת מחדל: 9050 או 0 כדי להשבית)</string>
-    <string name="pref_dnsport_summary">פתחה שדרכה יוגש ה־DNS של תור (ברירת מחדל: 5400 או 0 כדי להשבית)</string>
+    <string name="pref_dnsport_summary">פתחה שדרכה יוגש ה־DNS של תור (ברירת מחדל: 9053 או 0 כדי להשבית)</string>
     <string name="pref_dnsport_dialog">תצורת פתחת DNS</string>
     <string name="pref_torrc_title">תצורה מותאמת אישית של Torrc</string>
     <string name="pref_torrc_summary">מומחים בלבד: הכנסת שורות תצורת torrc ישירות</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -88,7 +88,7 @@
     <string name="pref_transport_summary">Tor が透過プロキシを提供するポート (初期設定: 9040、0にすると無効)</string>
     <string name="pref_transport_dialog">透過プロキシポート設定</string>
     <string name="pref_dnsport_title">Tor DNS ポート</string>
-    <string name="pref_dnsport_summary">Tor が DNS を提供するポート (初期設定: 5400、0にすると無効)</string>
+    <string name="pref_dnsport_summary">Tor が DNS を提供するポート (初期設定: 9053、0にすると無効)</string>
     <string name="pref_dnsport_dialog">DNS ポート設定</string>
     <string name="pref_torrc_title">Torrc カスタム設定</string>
     <string name="pref_torrc_summary">上級者向け: 直接 torrc 設定行を入力します</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -86,7 +86,7 @@
     <string name="pref_transport_summary">투명프록시에 사용할 포트 (기본: 9040 / 0은 비활성화)</string>
     <string name="pref_transport_dialog">투명프록시 포트 설정</string>
     <string name="pref_dnsport_title">토르 DNS 포트</string>
-    <string name="pref_dnsport_summary">토르 DNS를 제공할 포트 (기본: 5400 / 0은 비활성화)</string>
+    <string name="pref_dnsport_summary">토르 DNS를 제공할 포트 (기본: 9053 / 0은 비활성화)</string>
     <string name="pref_dnsport_dialog">DNS 포트 설정</string>
     <string name="pref_torrc_title">사용자 지정 Torrc 구성</string>
     <string name="pref_torrc_summary">전문가 전용: torrc 구성 줄을 직접 입력합니다</string>

--- a/app/src/main/res/values-lt-rLT/strings.xml
+++ b/app/src/main/res/values-lt-rLT/strings.xml
@@ -154,7 +154,7 @@
     <string name="pref_start_boot_summary">Automatiškai paleisti „Orbot“ ir prijunkti „Tor“, kai įsijungs „Android“ įrenginys</string>
     <string name="backup_service">Atsarginio kopijavimo paslauga <i>(Įspėjimas: tai gali atskleisti jūsų paslaugos konfigūraciją kitoms programoms)</i></string>
     <string name="enable_debug_log_to_output_must_use_adb_or_alogcat_to_view_">Įgalinti derinimo žurnalo išvestį (norėdami peržiūrėti turite naudoti adb arba aLogcat)</string>
-    <string name="pref_dnsport_summary">Prievadas, kuriuo „Tor“ siūlo savo DNS (numatytoji reikšmė: 5400 arba 0, jei norite išjungti)</string>
+    <string name="pref_dnsport_summary">Prievadas, kuriuo „Tor“ siūlo savo DNS (numatytoji reikšmė: 9053 arba 0, jei norite išjungti)</string>
     <string name="in_a_browser">Naršyklėje apsilankykite %s ir bakstelėkite Get Bridges &gt; Just Give Me Bridges!</string>
     <string name="pref_connection_padding_summary">Visada įjungiamas ryšio užpildymas, kad būtų apsisaugota nuo kai kurių srauto analizės formų. Numatytoji reikšmė: auto</string>
     <string name="pref_transport_summary">Prievadas, per kurį „Tor“ siūlo savo skaidrųjį įgaliotąjį serverį (numatytoji reikšmė: 9040 arba 0, jei norite išjungti)</string>

--- a/app/src/main/res/values-lv/strings.xml
+++ b/app/src/main/res/values-lv/strings.xml
@@ -86,7 +86,7 @@
     <string name="pref_transport_summary">Ports, uz kura Tor piedāvā savu Transparent starpniekserveri (noklusējumvērtība: 9040 vai 0 lai atspējotu)</string>
     <string name="pref_transport_dialog">TransProxy Port Config</string>
     <string name="pref_dnsport_title">Tor DNS Ports</string>
-    <string name="pref_dnsport_summary">Ports, uz kura Tor piedāvā savu DNS (noklusējumvērtība: 5400 vai 0 lai atspējotu)</string>
+    <string name="pref_dnsport_summary">Ports, uz kura Tor piedāvā savu DNS (noklusējumvērtība: 9053 vai 0 lai atspējotu)</string>
     <string name="pref_dnsport_dialog">DNS Port konfigurēšana</string>
     <string name="pref_torrc_title">Torrc pielāgota konfigurēšana</string>
     <string name="pref_torrc_summary">VIENĪGI EKSPERTIEM: tieši ievadīt torrc konfigurēšanas rindas</string>

--- a/app/src/main/res/values-mk/strings.xml
+++ b/app/src/main/res/values-mk/strings.xml
@@ -88,7 +88,7 @@
     <string name="pref_transport_summary">Порта на која Tor и го нуди својот транспарентен прокси (стандардно: 9040 или 0 за да се исклучи)</string>
     <string name="pref_transport_dialog">Поставување на портата за TransProxy</string>
     <string name="pref_dnsport_title">DNS-порта за Tor</string>
-    <string name="pref_dnsport_summary">Порта на која Tor го нуди својот DNS (стандардно: 5400 или 0 за да се исклучи)</string>
+    <string name="pref_dnsport_summary">Порта на која Tor го нуди својот DNS (стандардно: 9053 или 0 за да се исклучи)</string>
     <string name="pref_dnsport_dialog">Поставување на DNS-портата </string>
     <string name="pref_torrc_title">Прилагодено поставување на torrc</string>
     <string name="pref_torrc_summary">САМО ЗА ЕКСПЕРТИ: внесете директни команди за поставување на torrc</string>

--- a/app/src/main/res/values-nah/strings.xml
+++ b/app/src/main/res/values-nah/strings.xml
@@ -90,7 +90,7 @@
     <string name="pref_transport_summary">Acaltecoyan ic Tor quimaca Transparent Proxy (Achtopa:9040 nozo 0 ic quipopoloa)</string>
     <string name="pref_transport_dialog">Quitlayocoya iacaltecoyan TransProxy</string>
     <string name="pref_dnsport_title">Tzalantli DNS Tor</string>
-    <string name="pref_dnsport_summary">Acaltecoyan ic Tor quimaca DNS (Achtopa: 5400 nozo 0 ic quipopoloa)</string>
+    <string name="pref_dnsport_summary">Acaltecoyan ic Tor quimaca DNS (Achtopa: 9053 nozo 0 ic quipopoloa)</string>
     <string name="pref_dnsport_dialog">Mocentilia DNS tzalantli</string>
     <string name="pref_torrc_title">Quitlacoya zan Torrc</string>
     <string name="pref_torrc_summary">Zan tlamatinimeh: Xiquicalaqui in tequitl itlayocoyaliz</string>

--- a/app/src/main/res/values-nb/strings.xml
+++ b/app/src/main/res/values-nb/strings.xml
@@ -86,7 +86,7 @@
     <string name="pref_transport_summary">Porten Tor tilbyr transparent mellomtjening på (forvalg: 9040 eller 0 for å skru av)</string>
     <string name="pref_transport_dialog">Portoppsett for TransProxy</string>
     <string name="pref_dnsport_title">Tor DNS-port</string>
-    <string name="pref_dnsport_summary">Porten Tor tilbyr sin DNS-tjeneste på (forvalg: 5400 eller 0 for å skru av)</string>
+    <string name="pref_dnsport_summary">Porten Tor tilbyr sin DNS-tjeneste på (forvalg: 9053 eller 0 for å skru av)</string>
     <string name="pref_dnsport_dialog">DNS-portoppsett</string>
     <string name="pref_torrc_title">Egendefinert torrc-oppsett</string>
     <string name="pref_torrc_summary">BARE FOR EKSPERTER: skriv inn direkte torrc-oppsettslinjer</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -88,7 +88,7 @@
     <string name="pref_transport_summary">Poort waarop Tor de transparante proxy aanbiedt (standaard: 9040 of 0 om uit te schakelen)</string>
     <string name="pref_transport_dialog">TransProxy-poortconfiguratie</string>
     <string name="pref_dnsport_title">Tor DNS-poort</string>
-    <string name="pref_dnsport_summary">Poort waarop Tor de DNS aanbiedt (standaard: 5400 of 0 om uit te schakelen)</string>
+    <string name="pref_dnsport_summary">Poort waarop Tor de DNS aanbiedt (standaard: 9053 of 0 om uit te schakelen)</string>
     <string name="pref_dnsport_dialog">DNS-poortconfiguratie</string>
     <string name="pref_torrc_title">Torrc aangepaste configuratie</string>
     <string name="pref_torrc_summary">ENKEL VOOR GEVORDERDEN: voer rechtstreeks torrc-configuratieregels in</string>

--- a/app/src/main/res/values-pbb/strings.xml
+++ b/app/src/main/res/values-pbb/strings.xml
@@ -91,7 +91,7 @@ Notificaciones ampliadas</string>
   <string name="pref_transport_summary">Toryu’ naa vxitxkwetek proxy’s ũsu’ (naate: 9040 khimeeçxa 0 fxĩçxhawa’)</string>
   <string name="pref_transport_dialog">TransProxi vxitxkwe\'s phuse\'jwa\'</string>
   <string name="pref_dnsport_title">DNS Tor vxitx</string>
-  <string name="pref_dnsport_summary">Toryu’ naa vxitxkwetek DNSku ũsu’ (naate: 5400 khimeeçxa 0 fxĩçxhawa’)</string>
+  <string name="pref_dnsport_summary">Toryu’ naa vxitxkwetek DNSku ũsu’ (naate: 9053 khimeeçxa 0 fxĩçxhawa’)</string>
   <string name="pref_dnsport_dialog">DNS vxitxkwe\'s phuse\'jwa\'</string>
   <string name="pref_torrc_title">Idx phuse\'jnxi Torrc</string>
   <string name="pref_torrc_summary">MEH JIISA:  mki’ph Torrctewe’sx phuse’jnxi westxi</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -86,7 +86,7 @@
     <string name="pref_transport_summary">Port, na którym Tor oferuje swoje przezroczyste proxy (domyślnie: 9040 lub 0, aby wyłączyć)</string>
     <string name="pref_transport_dialog">Konfiguracja portu przezroczystego proxy</string>
     <string name="pref_dnsport_title">Port DNS Tor</string>
-    <string name="pref_dnsport_summary">Port na którym Tor oferuje swój DNS (domyślnie: 5400 lub 0, aby wyłączyć)</string>
+    <string name="pref_dnsport_summary">Port na którym Tor oferuje swój DNS (domyślnie: 9053 lub 0, aby wyłączyć)</string>
     <string name="pref_dnsport_dialog">Konfiguracja portu DNS</string>
     <string name="pref_torrc_title">Konfiguracja Torrc klienta</string>
     <string name="pref_torrc_summary">TYLKO DLA EKSPERTÓW: wpisz linijki konfiguracyjne torrc</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -88,7 +88,7 @@
     <string name="pref_transport_summary">Porta que Tor oferece seu Proxy Transparente no (padrão: 9040 ou 0 para desativar)</string>
     <string name="pref_transport_dialog">Config da Porta TransProxy</string>
     <string name="pref_dnsport_title">Porta DNS Tor</string>
-    <string name="pref_dnsport_summary">Porta que Tor oferece seu DNS no (padrão: 5400 ou 0 para desativar)</string>
+    <string name="pref_dnsport_summary">Porta que Tor oferece seu DNS no (padrão: 9053 ou 0 para desativar)</string>
     <string name="pref_dnsport_dialog">Config da Porta DNS</string>
     <string name="pref_torrc_title">Config Personalizada do Torrc</string>
     <string name="pref_torrc_summary">SOMENTE EXPERIENTES: adicione sua própria linha de configuração Torrc</string>

--- a/app/src/main/res/values-pt-rPT/strings.xml
+++ b/app/src/main/res/values-pt-rPT/strings.xml
@@ -121,7 +121,7 @@
     <string name="pref_torrc_summary">SOMENTE EXPERIENTES: adicione sua própria linha de configuração torrc</string>
     <string name="pref_torrc_title">Configuração Personalizada do Torrc</string>
     <string name="pref_dnsport_dialog">Configuração da Porta DNS</string>
-    <string name="pref_dnsport_summary">Porta em que Tor oferece DNS dele (predefinição: 5400 ou 0 para desativar)</string>
+    <string name="pref_dnsport_summary">Porta em que Tor oferece DNS dele (predefinição: 9053 ou 0 para desativar)</string>
     <string name="pref_transport_dialog">Configuração da Porta TransProxy</string>
     <string name="pref_transport_summary">Porta em que Tor oferece o Proxy Transparente dele (predefinição: 9040 ou 0 para desativar)</string>
     <string name="pref_transport_title">Porta TransProxy Tor</string>

--- a/app/src/main/res/values-ro-rRO/strings.xml
+++ b/app/src/main/res/values-ro-rRO/strings.xml
@@ -86,7 +86,7 @@
     <string name="pref_transport_summary">Porturi pe care Tor oferă Proxy-ul Transparent activ (principal:9040 sau 0 pentru dezactivare)</string>
     <string name="pref_transport_dialog">Portul Tor TransProxy </string>
     <string name="pref_dnsport_title">Portul DNS Tor</string>
-    <string name="pref_dnsport_summary">Porturi pe care Tor oferă DNS-ul activ (principal:5400 sau 0 pentru dezactivare)</string>
+    <string name="pref_dnsport_summary">Porturi pe care Tor oferă DNS-ul activ (principal:9053 sau 0 pentru dezactivare)</string>
     <string name="pref_dnsport_dialog">Configurare Port DNS</string>
     <string name="pref_torrc_title">Configurare personalizată Torrc</string>
     <string name="pref_torrc_summary">PENTRU EXPERŢI: introdu direct liniile de configurare ale torrc</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -88,7 +88,7 @@
     <string name="pref_transport_summary">Порт, на котором Tor предоставляет свой прозрачный прокси (по умолчанию: 9040, 0 — для отключения)</string>
     <string name="pref_transport_dialog">Настройка порта прозрачного прокси</string>
     <string name="pref_dnsport_title">Порт DNS Tor</string>
-    <string name="pref_dnsport_summary">Порт, на котором Tor предоставляет свой DNS (по умолчанию: 5400, 0 — для отключения)</string>
+    <string name="pref_dnsport_summary">Порт, на котором Tor предоставляет свой DNS (по умолчанию: 9053, 0 — для отключения)</string>
     <string name="pref_dnsport_dialog">Настройка порта DNS</string>
     <string name="pref_torrc_title">Пользовательские настройки Torrc</string>
     <string name="pref_torrc_summary">ТОЛЬКО ДЛЯ ЭКСПЕРТОВ: внесите настройки напрямую в строки файла конфигурации torrc</string>

--- a/app/src/main/res/values-sk-rSK/strings.xml
+++ b/app/src/main/res/values-sk-rSK/strings.xml
@@ -189,7 +189,7 @@
     <string name="pref_dnsport_dialog">Konfigurácia portu DNS</string>
     <string name="pref_transport_dialog">Konfigurácia portu TransProxy</string>
     <string name="pref_dnsport_title">Port Tor DNS</string>
-    <string name="pref_dnsport_summary">Port, na ktorom Tor ponúka svoj DNS (predvolené: 5400 alebo 0 pre vypnutie)</string>
+    <string name="pref_dnsport_summary">Port, na ktorom Tor ponúka svoj DNS (predvolené: 9053 alebo 0 pre vypnutie)</string>
     <string name="pref_torrc_title">Vlastná konfigurácia Torrc</string>
     <string name="pref_torrc_summary">Len pre odborníkov: zadajte priame konfiguračné riadky torrc</string>
     <string name="pref_torrc_dialog">Vlastné Torrc</string>

--- a/app/src/main/res/values-sl/strings.xml
+++ b/app/src/main/res/values-sl/strings.xml
@@ -134,7 +134,7 @@
     <string name="pref_transport_summary">vrata, na katerih Tor ponuja svoj transparentni proxy (privzeto: 9040 ali 0 za onemogočanje)</string>
     <string name="pref_transport_dialog">Konfiguracija pristanišča TransProxy</string>
     <string name="pref_dnsport_title">Tor DNS Port</string>
-    <string name="pref_dnsport_summary">vrata, na katerih Tor ponuja svoj DNS (privzeto: 5400 ali 0 za onemogočanje)</string>
+    <string name="pref_dnsport_summary">vrata, na katerih Tor ponuja svoj DNS (privzeto: 9053 ali 0 za onemogočanje)</string>
     <string name="pref_dnsport_dialog">Konfiguracija pristanišča DNS</string>
     <string name="pref_torrc_title">Konfiguracija po meri Torrc</string>
     <string name="pref_torrc_summary">Samo strokovnjaki: vnesite neposredne konfiguracijske vrstice torrc</string>

--- a/app/src/main/res/values-sq/strings.xml
+++ b/app/src/main/res/values-sq/strings.xml
@@ -158,7 +158,7 @@
     <string name="pref_http_dialog">Formësim Porte HTTP</string>
     <string name="pref_transport_title">Portë Tor TransProxy</string>
     <string name="pref_dnsport_title">Portë DNS Tor</string>
-    <string name="pref_dnsport_summary">Portë ku Tor-i ofron DNS-në e vet (parazgjedhje: 5400, ose 0 për ta çaktivizuar)</string>
+    <string name="pref_dnsport_summary">Portë ku Tor-i ofron DNS-në e vet (parazgjedhje: 9053, ose 0 për ta çaktivizuar)</string>
     <string name="pref_torrc_title">Formësim Torrc Vetjake</string>
     <string name="mebibyte">MiB</string>
     <string name="bridges_updated">Urat u Përditësuan</string>

--- a/app/src/main/res/values-sr/strings.xml
+++ b/app/src/main/res/values-sr/strings.xml
@@ -88,7 +88,7 @@
     <string name="pref_transport_summary">Port који Тор нуди је Transparent Proxy укључен (уобичајено: 9040 или 0 за искључивање)</string>
     <string name="pref_transport_dialog">TransProxy Port Подешавања</string>
     <string name="pref_dnsport_title">Toр DNS Port</string>
-    <string name="pref_dnsport_summary">Port који Тор нуди је DNS укључен (уобичајено: 5400 или 0 за искључивање)</string>
+    <string name="pref_dnsport_summary">Port који Тор нуди је DNS укључен (уобичајено: 9053 или 0 за искључивање)</string>
     <string name="pref_dnsport_dialog">DNS Port Подешавања</string>
     <string name="pref_torrc_title">Torrc Прерађена Подешавања</string>
     <string name="pref_torrc_summary">САМО ЗА ЕКСПЕРТЕ: унети директно torrc линије подешавања</string>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -88,7 +88,7 @@
     <string name="pref_transport_summary">Port som Tor erbjuder sin transparenta proxy på (standard: 9040 eller 0 för att inaktivera)</string>
     <string name="pref_transport_dialog">TransProxy-port-inställningar</string>
     <string name="pref_dnsport_title">Tor DNS-port</string>
-    <string name="pref_dnsport_summary">Port som Tor erbjuder sin DNS på (standard: 5400 eller 0 för att inaktivera)</string>
+    <string name="pref_dnsport_summary">Port som Tor erbjuder sin DNS på (standard: 9053 eller 0 för att inaktivera)</string>
     <string name="pref_dnsport_dialog">DNS-port-inställningar</string>
     <string name="pref_torrc_title">Torrc anpassad konfiguration</string>
     <string name="pref_torrc_summary">ENDAST EXPERTER: ange torrc konfiguration direkt</string>

--- a/app/src/main/res/values-ta/strings.xml
+++ b/app/src/main/res/values-ta/strings.xml
@@ -217,7 +217,7 @@
     <string name="pref_http_summary">துறைமுகம் அந்த டோர் அதன் HTTP ப்ராக்சியை வழங்குகிறது (இயல்புநிலை: 8118 அல்லது 0 முடக்க)</string>
     <string name="pref_http_dialog">HTTP துறைமுகம் கட்டமைப்பு</string>
     <string name="pref_transport_title">டோர் டிரான்ச்ப்ராக்சி துறைமுகம்</string>
-    <string name="pref_dnsport_summary">டோர் அதன் டி.என்.எச்சை வழங்கும் துறைமுகம் (இயல்புநிலை: 5400 அல்லது 0 முடக்க)</string>
+    <string name="pref_dnsport_summary">டோர் அதன் டி.என்.எச்சை வழங்கும் துறைமுகம் (இயல்புநிலை: 9053 அல்லது 0 முடக்க)</string>
     <string name="pref_dnsport_dialog">டி.என்.எச் துறைமுகம் கட்டமைப்பு</string>
     <string name="pref_torrc_title">டோர்க் தனிப்பயன் கட்டமைப்பு</string>
     <string name="pref_torrc_summary">வல்லுநர்கள் மட்டும்: நேரடி டோர்க் கட்டமைப்பு வரிகளை உள்ளிடவும்</string>

--- a/app/src/main/res/values-th/strings.xml
+++ b/app/src/main/res/values-th/strings.xml
@@ -88,7 +88,7 @@
     <string name="pref_transport_summary">พอร์ตที่ Tor ให้บริการพร็อกซีแบบ Transparent (ค่าเริ่มต้น: 9040 หรือ 0 ไปถึงไม่เปิดใช้งาน)</string>
     <string name="pref_transport_dialog">กำหนดค่าพอร์ตพร็อกซีแบบ Transparent</string>
     <string name="pref_dnsport_title">พอร์ต DNS ของ Tor</string>
-    <string name="pref_dnsport_summary">พอร์ตที่ Tor ให้บริการ DNS (ค่าเริ่มต้น: 5400 หรือ 0 ไปถึงไม่เปิดใช้งาน)</string>
+    <string name="pref_dnsport_summary">พอร์ตที่ Tor ให้บริการ DNS (ค่าเริ่มต้น: 9053 หรือ 0 ไปถึงไม่เปิดใช้งาน)</string>
     <string name="pref_dnsport_dialog">กำหนดค่าพอร์ต DNS</string>
     <string name="pref_torrc_title">กำหนดค่า Torrc เอง</string>
     <string name="pref_torrc_summary">สำหรับผู้เชี่ยวชาญเท่านั้น: ระบุบรรทัดที่กำหนดค่า torcc โดยตรง</string>

--- a/app/src/main/res/values-tk/strings.xml
+++ b/app/src/main/res/values-tk/strings.xml
@@ -233,7 +233,7 @@
     <string name="pref_http_summary">Tor, HTTP proksi hödürleýän port (deslapky: 8118 ýa-da 0 ýapmak üçin)</string>
     <string name="pref_transport_summary">Tor-uň aç-açan proksi hödürleýän porty (deslapky: 9040 ýa-da 0 ýapmak üçin)</string>
     <string name="pref_transport_dialog">TransProxy Port Sazlamalary</string>
-    <string name="pref_dnsport_summary">Tor DNS-i hödürleýän port (deslapky: 5400 ýa-da 0 ýapmak üçin)</string>
+    <string name="pref_dnsport_summary">Tor DNS-i hödürleýän port (deslapky: 9053 ýa-da 0 ýapmak üçin)</string>
     <string name="pref_torrc_title">Torrc Aýratyn Sazlamalar</string>
     <string name="pref_torrc_summary">HÜNARMENLER ÜÇIN: torrc sazlamalar setirlerini göni giriziň</string>
     <string name="pref_torrc_dialog">Aýratyn Torrc</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -88,7 +88,7 @@
     <string name="pref_transport_summary">Tor saydam vekil sunucusu için kullanılacak bağlantı noktası (öntanımlı değer: 9040 ya da devre dışı bırakmak için 0)</string>
     <string name="pref_transport_dialog">TransProxy Bağlantı Noktası Ayarı</string>
     <string name="pref_dnsport_title">Tor DNS Bağlantı Noktası</string>
-    <string name="pref_dnsport_summary">Tor DNS hizmeti için kullanılacak bağlantı noktası (öntanımlı değer: 5400 ya da devre dışı bırakmak için 0)</string>
+    <string name="pref_dnsport_summary">Tor DNS hizmeti için kullanılacak bağlantı noktası (öntanımlı değer: 9053 ya da devre dışı bırakmak için 0)</string>
     <string name="pref_dnsport_dialog">DNS Bağlantı Noktası Ayarı</string>
     <string name="pref_torrc_title">Özel Torrc Ayarları</string>
     <string name="pref_torrc_summary">UZMANLAR İÇİN: doğrudan torrc yapılandırma satırlarını girin</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -88,7 +88,7 @@
     <string name="pref_transport_summary">Порт, який Tor надає своєму відкритому проксі (усталено: 9040 або 0 для вимкнення)</string>
     <string name="pref_transport_dialog">Конфігурація порту Tor TransProxy</string>
     <string name="pref_dnsport_title">Порт Tor DNS</string>
-    <string name="pref_dnsport_summary">Порт, який Tor надає своєму DNS (усталено: 5400 або 0 для вимкнення)</string>
+    <string name="pref_dnsport_summary">Порт, який Tor надає своєму DNS (усталено: 9053 або 0 для вимкнення)</string>
     <string name="pref_dnsport_dialog">Конфігурація порту DNS</string>
     <string name="pref_torrc_title">Користувацькі конфігурації Torrc</string>
     <string name="pref_torrc_summary">ЛИШЕ ДЛЯ ЕКСПЕРТІВ: введіть конфігурації безпосередньо до рядків файлу torrc</string>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -86,7 +86,7 @@
     <string name="pref_transport_summary">Cổng để Tor đặt proxy trong suốt (TransProxy) lên (mặc định: 9040 hoặc 0 để vô hiệu hóa)</string>
     <string name="pref_transport_dialog">Cấu hình cổng proxy trong suốt (TransProxy)</string>
     <string name="pref_dnsport_title">Cổng DNS Tor</string>
-    <string name="pref_dnsport_summary">Cổng để Tor đặt DNS của nó lên (mặc định: 5400 hoặc 0 để vô hiệu hóa)</string>
+    <string name="pref_dnsport_summary">Cổng để Tor đặt DNS của nó lên (mặc định: 9053 hoặc 0 để vô hiệu hóa)</string>
     <string name="pref_dnsport_dialog">Cấu hình cổng DNS</string>
     <string name="pref_torrc_title">Cấu hình tùy chỉnh cho Torrc</string>
     <string name="pref_torrc_summary">CHỈ NGƯỜI DÙNG CHUYÊN MÔN: nhập các thiết lập trực tiếp cho torrc</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -86,7 +86,7 @@
     <string name="pref_transport_summary">Tor 提供透明代理的端口（默认值：9040，0 表示禁用）</string>
     <string name="pref_transport_dialog">透明代理端口配置</string>
     <string name="pref_dnsport_title">Tor DNS 端口</string>
-    <string name="pref_dnsport_summary">Tor 提供 DNS 的端口（默认值：5400，0 表示禁用）</string>
+    <string name="pref_dnsport_summary">Tor 提供 DNS 的端口（默认值：9053，0 表示禁用）</string>
     <string name="pref_dnsport_dialog">DNS 端口配置</string>
     <string name="pref_torrc_title">Torrc 自定义配置</string>
     <string name="pref_torrc_summary">仅供专家：直接输入 torrc 配置行</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -88,7 +88,7 @@
     <string name="pref_transport_summary">Tor 提供通透式代理的連接埠 (預設：9040，若設為 0 則關閉)</string>
     <string name="pref_transport_dialog">設定通透式代理連接埠</string>
     <string name="pref_dnsport_title">Tor DNS 埠</string>
-    <string name="pref_dnsport_summary">Tor 提供域名解析服務（DNS）的連接埠 (預設：5400，若設為0則關閉)</string>
+    <string name="pref_dnsport_summary">Tor 提供域名解析服務（DNS）的連接埠 (預設：9053，若設為0則關閉)</string>
     <string name="pref_dnsport_dialog">DNS連接埠設定</string>
     <string name="pref_torrc_title">Torrc 自訂設置</string>
     <string name="pref_torrc_summary">僅限專家：輸入 torrc 設定指令</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -96,7 +96,7 @@
     <string name="pref_transport_summary">Port that Tor offers its Transparent Proxy on (default: 9040 or 0 to disable)</string>
     <string name="pref_transport_dialog">TransProxy Port Config</string>
     <string name="pref_dnsport_title">Tor DNS Port</string>
-    <string name="pref_dnsport_summary">Port that Tor offers its DNS on (default: 5400 or 0 to disable)</string>
+    <string name="pref_dnsport_summary">Port that Tor offers its DNS on (default: 9053 or 0 to disable)</string>
     <string name="pref_dnsport_dialog">DNS Port Config</string>
     <string name="pref_torrc_title">Torrc Custom Config</string>
     <string name="pref_torrc_summary">EXPERTS ONLY: enter direct torrc config lines</string>

--- a/orbotservice/src/main/java/org/torproject/android/service/OrbotConstants.kt
+++ b/orbotservice/src/main/java/org/torproject/android/service/OrbotConstants.kt
@@ -13,9 +13,10 @@ object OrbotConstants {
 
     const val PREF_TOR_SHARED_PREFS = "org.torproject.android_preferences"
 
-    const val PREF_SOCKS = "pref_socks"
-
+    const val PREF_DNSPORT = "pref_dnsport"
     const val PREF_HTTP = "pref_http"
+    const val PREF_SOCKS = "pref_socks"
+    const val PREF_TRANSPORT = "pref_transport"
 
     const val PREF_ISOLATE_DEST = "pref_isolate_dest"
     const val PREF_ISOLATE_PORT = "pref_isolate_port"
@@ -29,11 +30,9 @@ object OrbotConstants {
     const val PREF_PREFER_IPV6 = "pref_prefer_ipv6"
     const val PREF_DISABLE_IPV4 = "pref_disable_ipv4"
 
-
     const val APP_TOR_KEY = "_app_tor"
     const val APP_DATA_KEY = "_app_data"
     const val APP_WIFI_KEY = "_app_wifi"
-
 
     const val DIRECTORY_TOR_DATA = "tordata"
 
@@ -41,12 +40,11 @@ object OrbotConstants {
     const val GEOIP_ASSET_KEY = "geoip"
     const val GEOIP6_ASSET_KEY = "geoip6"
 
-    const val TOR_TRANSPROXY_PORT_DEFAULT = 9040
-
-    const val TOR_DNS_PORT_DEFAULT = 5400
-
-    const val HTTP_PROXY_PORT_DEFAULT = "8118" // like Privoxy!
+    const val HTTP_PROXY_PORT_DEFAULT = "8118"
     const val SOCKS_PROXY_PORT_DEFAULT = "9050"
+
+    const val TOR_DNS_PORT_DEFAULT = 9053
+    const val TOR_TRANSPROXY_PORT_DEFAULT = 9040
 
     // control port
     const val LOG_NOTICE_HEADER = "NOTICE: "

--- a/orbotservice/src/main/java/org/torproject/android/service/OrbotService.java
+++ b/orbotservice/src/main/java/org/torproject/android/service/OrbotService.java
@@ -750,8 +750,8 @@ public class OrbotService extends VpnService {
             extraLines.append("ReducedCircuitPadding 1").append('\n');
         }
 
-        var transPort = prefs.getString("pref_transport", TOR_TRANSPROXY_PORT_DEFAULT + "");
-        var dnsPort = prefs.getString("pref_dnsport", TOR_DNS_PORT_DEFAULT + "");
+        var transPort = prefs.getString(PREF_TRANSPORT, String.valueOf(TOR_TRANSPROXY_PORT_DEFAULT));
+        var dnsPort = prefs.getString(PREF_DNSPORT, String.valueOf(TOR_DNS_PORT_DEFAULT));
 
         extraLines.append("TransPort ").append(checkPortOrAuto(transPort)).append(isolate).append('\n');
         extraLines.append("DNSPort ").append(checkPortOrAuto(dnsPort)).append(isolate).append('\n');
@@ -797,7 +797,7 @@ public class OrbotService extends VpnService {
                 if (isPortUsed) //the specified port is not available, so let Tor find one instead
                     port++;
             }
-            return port + "";
+            return String.valueOf(port);
         }
 
         return portString;


### PR DESCRIPTION
Fix Orbot constants and set default dns port to 9053 which is the same default as c-tor.