### PR TITLE
Redesign MoreFragment with a responsive grid layout

### DIFF
--- a/app/src/main/java/org/torproject/android/MoreFragment.kt
+++ b/app/src/main/java/org/torproject/android/MoreFragment.kt
@@ -1,5 +1,7 @@
 package org.torproject.android
 
+import android.animation.AnimatorSet
+import android.animation.ObjectAnimator
 import android.app.Activity
 import android.content.Intent
 import android.content.pm.PackageManager
@@ -7,10 +9,13 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import android.widget.ListView
+import android.view.animation.BounceInterpolator
+import android.widget.ImageView
 import android.widget.TextView
 
 import androidx.fragment.app.Fragment
+import androidx.recyclerview.widget.GridLayoutManager
+import androidx.recyclerview.widget.RecyclerView
 
 import org.torproject.android.OrbotActivity.Companion.REQUEST_CODE_SETTINGS
 import org.torproject.android.OrbotActivity.Companion.REQUEST_VPN_APP_SELECT
@@ -18,13 +23,14 @@ import org.torproject.android.core.sendIntentToService
 import org.torproject.android.core.ui.SettingsActivity
 import org.torproject.android.service.OrbotConstants
 import org.torproject.android.service.OrbotService
-import org.torproject.android.ui.*
+import org.torproject.android.ui.AboutDialogFragment
+import org.torproject.android.ui.AppManagerActivity
+import org.torproject.android.ui.MoreActionAdapter
+import org.torproject.android.ui.OrbotMenuAction
 import org.torproject.android.ui.v3onionservice.OnionServiceActivity
 import org.torproject.android.ui.v3onionservice.clientauth.ClientAuthActivity
 
 class MoreFragment : Fragment() {
-    private lateinit var lvMore: ListView
-
     private var httpPort = -1
     private var socksPort = -1
 
@@ -39,7 +45,6 @@ class MoreFragment : Fragment() {
 
         if (view != null) updateStatus()
     }
-
 
     /**
     fun setPorts(newHttpPort: Int, newSocksPort: Int) {
@@ -72,42 +77,60 @@ class MoreFragment : Fragment() {
     }
 
     override fun onCreateView(
-        inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
     ): View? {
         val view = inflater.inflate(R.layout.fragment_more, container, false)
         tvStatus = view.findViewById(R.id.tvVersion)
 
         updateStatus()
-        lvMore = view.findViewById(R.id.lvMoreActions)
 
-        val listItems =
-            arrayListOf(OrbotMenuAction(R.string.v3_hosted_services, R.drawable.ic_menu_onion) {
+        val rvMore = view.findViewById<RecyclerView>(R.id.rvMoreActions)
+        val ivMascot = view.findViewById<ImageView>(R.id.ivMascot)
+
+        val listItems = listOf(
+            OrbotMenuAction(R.string.v3_hosted_services, R.drawable.ic_menu_onion) {
                 startActivity(Intent(requireActivity(), OnionServiceActivity::class.java))
             },
-                OrbotMenuAction(
-                    R.string.v3_client_auth_activity_title, R.drawable.ic_shield
-                ) { startActivity(Intent(requireActivity(), ClientAuthActivity::class.java)) },
-                OrbotMenuAction(R.string.btn_choose_apps, R.drawable.ic_choose_apps) {
-                    activity?.startActivityForResult(
-                        Intent(
-                            requireActivity(), AppManagerActivity::class.java
-                        ), REQUEST_VPN_APP_SELECT
-                    )
-                },
-                OrbotMenuAction(R.string.menu_settings, R.drawable.ic_settings_gear) {
+            OrbotMenuAction(R.string.v3_client_auth_activity_title, R.drawable.ic_shield) {
+                startActivity(Intent(requireActivity(), ClientAuthActivity::class.java))
+            },
+            OrbotMenuAction(R.string.btn_choose_apps, R.drawable.ic_choose_apps) {
+                activity?.startActivityForResult(
+                    Intent(requireActivity(), AppManagerActivity::class.java), REQUEST_VPN_APP_SELECT
+                )
+            },
+            OrbotMenuAction(R.string.menu_settings, R.drawable.ic_settings_gear) {
+                activity?.startActivityForResult(
+                    Intent(context, SettingsActivity::class.java), REQUEST_CODE_SETTINGS
+                )
+            },
+            OrbotMenuAction(R.string.menu_log, R.drawable.ic_log) { showLog() },
+            OrbotMenuAction(R.string.menu_about, R.drawable.ic_about) {
+                AboutDialogFragment().show(
+                    requireActivity().supportFragmentManager, AboutDialogFragment.TAG
+                )
+            },
+            OrbotMenuAction(R.string.menu_exit, R.drawable.ic_exit) { doExit() }
+        )
+        rvMore.adapter = MoreActionAdapter(listItems)
 
-                    activity?.startActivityForResult(
-                        Intent(context, SettingsActivity::class.java), REQUEST_CODE_SETTINGS
-                    )
-                },
-                OrbotMenuAction(R.string.menu_log, R.drawable.ic_log) { showLog() },
-                OrbotMenuAction(R.string.menu_about, R.drawable.ic_about) {
-                    AboutDialogFragment().show(
-                        requireActivity().supportFragmentManager, AboutDialogFragment.TAG
-                    )
-                },
-                OrbotMenuAction(R.string.menu_exit, R.drawable.ic_exit) { doExit() })
-        lvMore.adapter = MoreActionAdapter(requireActivity(), listItems)
+        val spanCount = if (resources.configuration.screenWidthDp < 600) 2 else 4
+        rvMore.layoutManager = GridLayoutManager(requireContext(), spanCount)
+
+        ivMascot.setOnClickListener {
+            val scaleX = ObjectAnimator.ofFloat(it, View.SCALE_X, 1f, 1.2f, 1f)
+            val scaleY = ObjectAnimator.ofFloat(it, View.SCALE_Y, 1f, 1.2f, 1f)
+            val rotate = ObjectAnimator.ofFloat(it, View.ROTATION, 0f, 10f, -10f, 0f)
+
+            AnimatorSet().apply {
+                playTogether(scaleX, scaleY, rotate)
+                duration = 500
+                interpolator = BounceInterpolator()
+                start()
+            }
+        }
 
         return view
     }
@@ -115,7 +138,6 @@ class MoreFragment : Fragment() {
     private fun getTorVersion(): String {
         return OrbotService.BINARY_TOR_VERSION.split("-").toTypedArray()[0]
     }
-
 
     private fun doExit() {
         val killIntent = Intent(
@@ -130,5 +152,4 @@ class MoreFragment : Fragment() {
     private fun showLog() {
         (activity as OrbotActivity).showLog()
     }
-
 }

--- a/app/src/main/java/org/torproject/android/ui/MoreActionAdapter.kt
+++ b/app/src/main/java/org/torproject/android/ui/MoreActionAdapter.kt
@@ -1,34 +1,36 @@
 package org.torproject.android.ui
 
-import android.content.Context
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import android.widget.*
+import android.widget.ImageView
+import android.widget.TextView
+
+import androidx.recyclerview.widget.RecyclerView
+
 import org.torproject.android.R
-import java.util.*
 
+class MoreActionAdapter(
+    private val items: List<OrbotMenuAction>
+) : RecyclerView.Adapter<MoreActionAdapter.ViewHolder>() {
 
-class MoreActionAdapter(context: Context, list: ArrayList<OrbotMenuAction>) : ArrayAdapter<OrbotMenuAction>(context,
-    R.layout.action_list_view, list) {
-
-    private val layoutInflater =
-        context.getSystemService(Context.LAYOUT_INFLATER_SERVICE) as LayoutInflater
-
-    override fun getView(position: Int, convertView: View?, parent: ViewGroup): View {
-        val returnView = convertView ?: layoutInflater.inflate(R.layout.action_list_view, null)
-        getItem(position)?.let { model ->
-            val imgView = returnView.findViewById<ImageView>(R.id.ivAction)
-            val tvAction = returnView.findViewById<TextView>(R.id.tvEmoji)
-
-            tvAction.visibility = View.GONE
-            imgView.visibility = View.VISIBLE
-            imgView.setImageResource(model.imgId)
-
-            returnView.findViewById<TextView>(R.id.tvLabel).text = context.getString(model.textId)
-            returnView.setOnClickListener { model.action() }
-        }
-        return returnView
+    inner class ViewHolder(view: View) : RecyclerView.ViewHolder(view) {
+        val icon: ImageView = view.findViewById(R.id.ivIcon)
+        val label: TextView = view.findViewById(R.id.tvLabel)
     }
 
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolder {
+        val view = LayoutInflater.from(parent.context)
+            .inflate(R.layout.item_more_action, parent, false)
+        return ViewHolder(view)
+    }
+
+    override fun getItemCount() = items.size
+
+    override fun onBindViewHolder(holder: ViewHolder, position: Int) {
+        val item = items[position]
+        holder.icon.setImageResource(item.imgId)
+        holder.label.setText(item.textId)
+        holder.itemView.setOnClickListener { item.action() }
+    }
 }

--- a/app/src/main/res/layout/fragment_more.xml
+++ b/app/src/main/res/layout/fragment_more.xml
@@ -6,26 +6,26 @@
     android:orientation="vertical"
     tools:context=".MoreFragment">
 
-    <!-- TODO: Update blank fragment layout -->
-    <ListView
-        android:drawSelectorOnTop="true"
-        android:layout_marginTop="10dp"
-        android:dividerHeight="1dp"
-        android:layout_marginLeft="24dp"
-        android:layout_marginRight="24dp"
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/rvMoreActions"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:id="@+id/lvMoreActions" />
+        android:padding="16dp"
+        android:clipToPadding="false"
+        tools:listitem="@layout/item_more_action" />
 
     <TextView
         android:id="@+id/tvVersion"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        android:layout_margin="12dp"
+        android:gravity="center"
         tools:text="Orbot vX.X.X" />
 
     <ImageView
-        android:layout_width="64dp"
-        android:layout_height="64dp"
+        android:id="@+id/ivMascot"
+        android:layout_width="48dp"
+        android:layout_height="48dp"
         android:src="@drawable/orbion"
         android:layout_margin="12dp"
         android:layout_gravity="center_horizontal" />

--- a/app/src/main/res/layout/item_more_action.xml
+++ b/app/src/main/res/layout/item_more_action.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.cardview.widget.CardView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_margin="8dp"
+    android:foreground="?android:attr/selectableItemBackground"
+    android:clickable="true"
+    android:focusable="true"
+    app:cardCornerRadius="16dp"
+    app:cardElevation="4dp"
+    app:cardBackgroundColor="@color/panel_widget_background">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:padding="16dp"
+        android:gravity="center_horizontal">
+
+        <ImageView
+            android:id="@+id/ivIcon"
+            android:layout_width="36dp"
+            android:layout_height="36dp"
+            android:contentDescription="@null"
+            app:tint="@color/panel_card_image" />
+
+        <TextView
+            android:id="@+id/tvLabel"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            android:textSize="12sp"
+            android:textStyle="bold"
+            android:textColor="@android:color/white" />
+
+    </LinearLayout>
+</androidx.cardview.widget.CardView>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -10,4 +10,5 @@
         <color name="new_background_secondary">#1C1425</color>
         <color name="text_purple">#A06DDF</color>
         <color name="panel_widget_background">#272030</color>
+        <color name="panel_card_image">#CAADED</color>
 </resources>


### PR DESCRIPTION
Improves the more fragment by:
1. Implementing a more material style
2. Increasing the touch targets
3. Refreshing the old colours
4. Making the icons bigger
5. Increasing the spacing

Tested on Pixel 8 API 35 and Pixel Tablet API 34.

<table>
    <tr>
        <th>Before</th>
        <th>After</th>
    </tr>
    <tr>
        <td><img src="https://github.com/user-attachments/assets/3f848e1c-0834-4bb6-8e8c-152e382ee900" width="270" height="600">
</td>
        <td><img src="https://github.com/user-attachments/assets/8f4e96d9-24ab-4626-b78d-22c21a3f794d" width="270" height="600"></td>
    </tr>
</table>
<table>
    <tr>
        <th>Before</th>
        <th>After</th>
    </tr>
    <tr>
        <td><img src="https://github.com/user-attachments/assets/530c9a8c-2b77-4661-9feb-fe73bc012d17"></td>
        <td><img src="https://github.com/user-attachments/assets/8ef79362-b927-4354-a9a8-1c3063852b92"></td>
    </tr>
</table>