### PR TITLE
Add setting to keep isolated circuits alive

### DIFF
--- a/app-tv/src/main/res/values/strings.xml
+++ b/app-tv/src/main/res/values/strings.xml
@@ -181,6 +181,8 @@
     <string name="pref_isolate_port_summary">Use a different circuit for each destination port</string>
     <string name="pref_isolate_protocol">Isolate client protocols</string>
     <string name="pref_isolate_protocol_summary">Use a different circuit for each connecting protocol</string>
+    <string name="pref_isolate_keep_alive">Keep isolated circuits alive</string>
+    <string name="pref_isolate_keep_alive_summary">Keep isolated circuits alive that have at least one stream with SOCKS authentication active</string>
     <string name="pref_connection_padding">Connection padding</string>
     <string name="pref_connection_padding_summary">Always enables connection padding to defend against some forms of traffic analysis. Default: auto</string>
     <string name="pref_reduced_connection_padding">Reduced connection padding</string>

--- a/app-tv/src/main/res/xml/preferences.xml
+++ b/app-tv/src/main/res/xml/preferences.xml
@@ -201,6 +201,12 @@
             android:summary="@string/pref_isolate_protocol_summary"
             android:title="@string/pref_isolate_protocol" />
         <CheckBoxPreference
+            android:defaultValue="false"
+            android:enabled="true"
+            android:key="pref_isolate_keep_alive"
+            android:summary="@string/pref_isolate_keep_alive_summary"
+            android:title="@string/pref_isolate_keep_alive" />
+        <CheckBoxPreference
             android:defaultValue="true"
             android:enabled="true"
             android:key="pref_prefer_ipv6"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -153,6 +153,8 @@
     <string name="pref_isolate_port_summary">Use a different circuit for each destination port</string>
     <string name="pref_isolate_protocol">Isolate client protocols</string>
     <string name="pref_isolate_protocol_summary">Use a different circuit for each connecting protocol</string>
+    <string name="pref_isolate_keep_alive">Keep isolated circuits alive</string>
+    <string name="pref_isolate_keep_alive_summary">Keep isolated circuits alive that have at least one stream with SOCKS authentication active</string>
     <string name="pref_connection_padding">Connection padding</string>
     <string name="pref_connection_padding_summary">Always enables connection padding to defend against some forms of traffic analysis. Default: auto</string>
     <string name="pref_reduced_connection_padding">Reduced connection padding</string>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -198,6 +198,14 @@
             app:iconSpaceReserved="false"
             />
         <CheckBoxPreference
+            android:defaultValue="false"
+            android:enabled="true"
+            android:key="pref_isolate_keep_alive"
+            android:summary="@string/pref_isolate_keep_alive_summary"
+            android:title="@string/pref_isolate_keep_alive"
+            app:iconSpaceReserved="false"
+            />
+        <CheckBoxPreference
             android:defaultValue="true"
             android:enabled="true"
             android:key="pref_prefer_ipv6"

--- a/orbotservice/src/main/java/org/torproject/android/service/OrbotConstants.kt
+++ b/orbotservice/src/main/java/org/torproject/android/service/OrbotConstants.kt
@@ -21,6 +21,7 @@ object OrbotConstants {
     const val PREF_ISOLATE_DEST = "pref_isolate_dest"
     const val PREF_ISOLATE_PORT = "pref_isolate_port"
     const val PREF_ISOLATE_PROTOCOL = "pref_isolate_protocol"
+    const val PREF_ISOLATE_KEEP_ALIVE = "pref_isolate_keep_alive"
 
     const val PREF_CONNECTION_PADDING = "pref_connection_padding"
     const val PREF_REDUCED_CONNECTION_PADDING = "pref_reduced_connection_padding"

--- a/orbotservice/src/main/java/org/torproject/android/service/OrbotService.java
+++ b/orbotservice/src/main/java/org/torproject/android/service/OrbotService.java
@@ -714,6 +714,9 @@ public class OrbotService extends VpnService {
         if (prefs.getBoolean(PREF_ISOLATE_PROTOCOL, false)) {
             isolate += " IsolateClientProtocol ";
         }
+        if (prefs.getBoolean(PREF_ISOLATE_KEEP_ALIVE, false)) {
+            isolate += " KeepAliveIsolateSOCKSAuth ";
+        }
 
         var ipv6Pref = "";
         if (prefs.getBoolean(PREF_PREFER_IPV6, true)) {


### PR DESCRIPTION
Add setting to enable KeepAliveIsolateSOCKSAuth to keep alive isolated circuits that have at least one stream with SOCKS authentication active. After such a circuit is idle for more than MaxCircuitDirtiness seconds, it can be closed.

This option is default for Tor Browser.