### PR TITLE
Dialog and permission logic needed for power user mode regarding #1263

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -18,6 +18,7 @@
     <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
 
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_SYSTEM_EXEMPTED" />
+    <uses-permission android:name="android.permission.SCHEDULE_EXACT_ALARM"/>
 
     <uses-permission android:name="android.permission.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS" />
 

--- a/app/src/main/java/org/torproject/android/ui/RequestScheduleExactAlarmDialogFragment.kt
+++ b/app/src/main/java/org/torproject/android/ui/RequestScheduleExactAlarmDialogFragment.kt
@@ -1,0 +1,34 @@
+package org.torproject.android.ui
+
+import android.app.Dialog
+import android.content.DialogInterface
+import android.content.Intent
+import android.net.Uri
+import android.os.Build
+import android.os.Bundle
+import android.provider.Settings
+import androidx.annotation.RequiresApi
+import androidx.appcompat.app.AlertDialog
+import androidx.fragment.app.DialogFragment
+import org.torproject.android.R
+
+class RequestScheduleExactAlarmDialogFragment : DialogFragment() {
+    @RequiresApi(Build.VERSION_CODES.S)
+    override fun onCreateDialog(savedInstanceState: Bundle?): Dialog =
+        AlertDialog.Builder(requireActivity())
+            .setTitle(R.string.power_user_mode_permission)
+            .setMessage(R.string.power_user_mode_permission_msg)
+            .setNegativeButton(
+                android.R.string.cancel,
+                DialogInterface.OnClickListener { dialog: DialogInterface?, which: Int -> dialog!!.cancel() })
+            .setPositiveButton(
+                android.R.string.yes,
+                DialogInterface.OnClickListener { dialog: DialogInterface?, which: Int ->
+                    val intent = Intent(Settings.ACTION_REQUEST_SCHEDULE_EXACT_ALARM).apply {
+                        data = Uri.fromParts("package", requireContext().packageName, null)
+                    }
+                    startActivity(intent)
+                    dismiss()
+                })
+            .create()
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -293,7 +293,6 @@
     <string name="app_icon_chooser_label_fit_grit">FitGrit</string>
     <string name="app_icon_chooser_label_birdie">Birdie</string>
 
-
     <string name="camo_dialog_title" formatted="true">Camouflage as %1$s</string>
     <string name="camo_dialog_enable_confirm_msg" formatted="true">Orbot will camouflage itself as the app %1$s. This will hide all notification details about Tor and change how the appearance of Orbot on your home screen.\n\nCamouflaging as %2$s will restart Orbot.</string>
     <string name="camo_dialog_disable_confirm_msg">Orbot will resume displaying notification information about your Tor connection and will appear as normal on your home screen.\n\nDisabling Camouflage Mode will restart Orbot.</string>
@@ -301,4 +300,6 @@
 
     <string name="pref_camo_mode_title">Camouflage Mode</string>
     <string name="pref_camo_mode_description">Disguise how Orbot\'s icon, label and notification text will appear on your device</string>
+    <string name="power_user_mode_permission">Alarms &amp; Reminders Permission Needed for Power User Mode</string>
+    <string name="power_user_mode_permission_msg">Please allow Orbot to set alarms and reminders in order to use power user mode. This won\'t actually set any alarms on your device. This permission is needed to have the system keep OrbotService running when Orbot is not being used as a system-wide VPN.</string>
 </resources>


### PR DESCRIPTION
For a detailed description of why this code is added, please see my comments in #1263 

This PR:

- Adds the `SCHEDULE_EXACT_ALARMS` permission to the manifest 
- Implements a dialog for power user mode to ensure that this permission is granted at runtime before `OrbotService` is started in power user mode.

![a](https://github.com/user-attachments/assets/08f96745-3c14-4b3c-8552-24a427324385)
![b](https://github.com/user-attachments/assets/4cb297d6-2377-4798-b2eb-af1d747a3a1f)
![c](https://github.com/user-attachments/assets/126010d6-a581-4169-9525-2e05aacf20e8)

