### PR TITLE
Fix potential crash in setPreferenceForSmartConnect()

### DIFF
--- a/app/src/main/java/org/torproject/android/ConfigConnectionBottomSheet.kt
+++ b/app/src/main/java/org/torproject/android/ConfigConnectionBottomSheet.kt
@@ -201,9 +201,6 @@ class ConfigConnectionBottomSheet :
         if (pref.equals(Prefs.PATHWAY_DIRECT)) rbDirect.isChecked = true
     }
 
-    private var circumventionApiBridges: List<Bridges?>? = null
-    private var circumventionApiIndex = 0
-
     private fun askTor() {
 
         val dLeft = AppCompatResources.getDrawable(requireContext(), R.drawable.ic_faq)
@@ -236,7 +233,7 @@ class ConfigConnectionBottomSheet :
 
         CircumventionApiManager(proxy.port(IPtProxy.MeekLite)).getSettings(SettingsRequest(countryCodeValue), {
             it?.let {
-                circumventionApiBridges = it.settings
+                var circumventionApiBridges = it.settings
                 if (circumventionApiBridges == null) {
                     //Log.d("abc", "settings is null, we can assume a direct connect is fine ")
                     rbDirect.isChecked = true
@@ -249,7 +246,7 @@ class ConfigConnectionBottomSheet :
                     }
 
                     //got bridges, let's set them
-                    setPreferenceForSmartConnect()
+                    setPreferenceForSmartConnect(circumventionApiBridges)
                 }
 
                 proxy.stop(IPtProxy.MeekLite)
@@ -280,21 +277,17 @@ class ConfigConnectionBottomSheet :
 
     }
 
-    private fun setPreferenceForSmartConnect() {
-
+    private fun setPreferenceForSmartConnect(circumventionApiBridges: List<Bridges?>?) {
         val dLeft = AppCompatResources.getDrawable(requireContext(), R.drawable.ic_green_check)
         btnAskTor.setCompoundDrawablesWithIntrinsicBounds(dLeft, null, null, null)
-
         circumventionApiBridges?.let {
-            if (it.size == circumventionApiIndex) {
-                circumventionApiBridges = null
-                circumventionApiIndex = 0
+            if (it.size == 0) {
                 rbDirect.isChecked = true
                 btnAskTor.text = getString(R.string.connection_direct)
 
                 return
             }
-            val b = it[circumventionApiIndex]!!.bridges
+            val b = it[0]!!.bridges
             when (b.type) {
                 CircumventionApiManager.BRIDGE_TYPE_SNOWFLAKE -> {
                     Prefs.putConnectionPathway(Prefs.PATHWAY_SNOWFLAKE)
@@ -318,7 +311,6 @@ class ConfigConnectionBottomSheet :
                     rbDirect.isChecked = true
                 }
             }
-            circumventionApiIndex += 1
         }
     }
 }


### PR DESCRIPTION
Setting both circumventionApiBridges and circumventionApiIndex as class variables could result in a crash if the list of bridges shrinks unexpectedly on a subsequent call to setPreferenceForSmartConnect(). Since circumventionApiBridges is not accessed outside of this function, this makes it a function input rather than a class variable.

Consider the following example:
- a User selects "ASK TOR" and [`CircumventionApiManager.getSettings`](https://github.com/guardianproject/orbot-android/blob/cd946c986a4debb8cd824e72f4f677357d2c8e86/app/src/main/java/org/torproject/android/ConfigConnectionBottomSheet.kt#L237C9-L237C76) returns a `List<Bridges?>` of size 2, which is set in `circumventionApiBridges`. `setPreferenceForSmartConnect()` is called and `circumventionApiIndex` is set to 1.
- a User selects "ASK TOR" again and circumventionApiIndex is set to 2.
- a User selects "ASK TOR" again and this time, `CircumventionApiManager.getSettings` returns a `List<Bridges?>` of size 1. Since the check [`it.size == circumventionApiIndex`](https://github.com/guardianproject/orbot-android/blob/cd946c986a4debb8cd824e72f4f677357d2c8e86/app/src/main/java/org/torproject/android/ConfigConnectionBottomSheet.kt#L289) is false, there will be an [out of index access](https://github.com/guardianproject/orbot-android/blob/cd946c986a4debb8cd824e72f4f677357d2c8e86/app/src/main/java/org/torproject/android/ConfigConnectionBottomSheet.kt#L297) that will cause a crash

Using class variables also makes this unsafe code to be called concurrently, which could happen in theory. I'm not sure of the reason for updating the index on each call, so it would be good to check that always using the 0 index (which should correspond to the top priority bridge settings) is the desired behaviour here. Another potential way to solve this is to have a more robust check of `circumventionApiIndex` against the size of the current list.