### PR TITLE
Use current list of defined bridge types

### DIFF
--- a/app/src/main/java/org/torproject/android/ui/onboarding/CustomBridgesFragment.kt
+++ b/app/src/main/java/org/torproject/android/ui/onboarding/CustomBridgesFragment.kt
@@ -167,7 +167,7 @@ class CustomBridgesFragment : Fragment(), TextWatcher {
         private const val URL_TOR_BRIDGES = "https://bridges.torproject.org/bridges"
 
         private fun userHasSetPreconfiguredBridge(bridges: String?): Boolean {
-            return bridges in listOf("obfs4", "meek", "snowflake", "snowflake-amp")
+            return bridges in listOf("obfs4", "meek", "snowflake", "webtunnel")
         }
     }
 }


### PR DESCRIPTION
There is no "snowflake-amp" bridge type defined anymore. These undefined bridge types are left over from the older version of IPtProxy.