### PR TITLE
Refresh activity layout with segmented button

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -70,6 +70,7 @@
             android:theme="@style/OrbotActivityTheme" />
 
         <activity
+            android:theme="@style/OrbotActivityMaterialTheme"
             android:name=".ui.v3onionservice.OnionServiceActivity"
             android:label="@string/v3_hosted_services" />
 

--- a/app/src/main/res/layout/activity_hosted_services.xml
+++ b/app/src/main/res/layout/activity_hosted_services.xml
@@ -13,11 +13,14 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content">
 
-        <androidx.appcompat.widget.Toolbar
+        <com.google.android.material.appbar.MaterialToolbar
             android:id="@+id/toolbar"
             android:baselineAligned="false"
             android:layout_width="match_parent"
-            android:layout_height="?attr/actionBarSize"/>
+            android:layout_height="?attr/actionBarSize"
+            android:background="@color/new_background"
+            app:titleTextColor="@android:color/white"
+            app:titleCentered="true" />
 
     </com.google.android.material.appbar.AppBarLayout>
 
@@ -28,7 +31,8 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_gravity="bottom|end"
-        android:layout_margin="@dimen/fab_margin"
+        android:layout_marginStart="@dimen/fab_margin"
+        android:layout_marginEnd="@dimen/fab_margin"
         android:tint="@android:color/black"
         app:fabSize="normal"
         app:backgroundTint="@color/progress_bar_purple"

--- a/app/src/main/res/layout/layout_hs_list_view_main.xml
+++ b/app/src/main/res/layout/layout_hs_list_view_main.xml
@@ -14,34 +14,39 @@
     tools:context="org.torproject.android.ui.v3onionservice.OnionServiceActivity"
     tools:showIn="@layout/activity_hosted_services">
 
-
-    <TextView
+    <com.google.android.material.textview.MaterialTextView
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginBottom="2dp"
         android:text="@string/service_type" />
 
-    <RadioGroup
-        android:paddingStart="-5dp"
+    <com.google.android.material.button.MaterialButtonToggleGroup
+        android:id="@+id/toggleButtonGroup"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_marginBottom="@dimen/activity_vertical_margin"
-        android:orientation="horizontal">
+        app:singleSelection="true">
 
-        <RadioButton
+        <com.google.android.material.button.MaterialButton
             android:id="@+id/radioUserServices"
-            android:layout_width="140dp"
+            style="@style/SegmentedButtonStyle"
+            android:backgroundTint="@color/orbot_btn_enabled_purple"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
-            android:onClick="onRadioButtonClick"
-            android:text="@string/user_services" />
+            android:layout_weight="1"
+            android:text="@string/user_services"
+            app:cornerRadius="10dp" />
 
-        <RadioButton
+        <com.google.android.material.button.MaterialButton
             android:id="@+id/radioAppServices"
-            android:layout_width="140dp"
+            style="@style/SegmentedButtonStyle"
+            android:backgroundTint="@color/orbot_btn_disable_grey"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
-            android:onClick="onRadioButtonClick"
-            android:text="@string/app_services" />
-    </RadioGroup>
+            android:layout_weight="1"
+            android:text="@string/app_services"
+            app:cornerRadius="10dp" />
+    </com.google.android.material.button.MaterialButtonToggleGroup>
 
     <ListView
         android:id="@+id/onion_list"

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -31,4 +31,11 @@
     <style name="BottomSheetRadio" parent="android:Widget.CompoundButton.RadioButton">
         <item name="buttonTint">@color/menu_header</item>
     </style>
+
+    <style name="SegmentedButtonStyle" parent="Widget.MaterialComponents.Button">
+        <item name="android:foreground">?attr/selectableItemBackground</item>
+        <item name="android:textColor">@color/panel_background_main</item>
+        <item name="android:textAppearance">@style/TextAppearance.Material3.TitleMedium</item>
+    </style>
+
 </resources>

--- a/app/src/main/res/values/theme.xml
+++ b/app/src/main/res/values/theme.xml
@@ -16,6 +16,14 @@
         <item name="colorPrimaryDark">@color/new_background_secondary</item>
     </style>
 
+    <style name="OrbotActivityMaterialTheme" parent="Theme.MaterialComponents.NoActionBar">
+        <item name="android:statusBarColor">@color/new_background_secondary</item>
+        <item name="android:windowBackground">@color/new_background_secondary</item>
+        <item name="android:windowIsFloating">false</item>
+        <item name="colorPrimary">@color/new_background_secondary</item>
+        <item name="colorPrimaryDark">@color/new_background_secondary</item>
+    </style>
+
     <style name="OrbotDialogTheme" parent="Theme.AppCompat.Light.Dialog.Alert">
         <item name="android:background">@color/new_background_secondary</item>
         <item name="android:textColor">@android:color/white</item>


### PR DESCRIPTION
Improves the design, colours, and the overall layout of the `OnionServiceActivity`.

<table>
    <tr>
        <th>Before</th>
        <th>After</th>
    </tr>
    <tr>
        <td><img src="https://github.com/user-attachments/assets/809942a5-027d-45c5-868e-e924007176bc" width="270" height="600">
</td>
        <td><img src="https://github.com/user-attachments/assets/d543c4d7-6a6c-43e7-a1ed-16ac0a2d609d" width="270" height="600"></td>
    </tr>
</table>

Closes #843 

Tested on Pixel 8 API 35.