### PR TITLE
Orbot Authentication Corner Cases and Bug Fixes 

### DIFF
--- a/app/src/main/java/org/torproject/android/OrbotActivity.kt
+++ b/app/src/main/java/org/torproject/android/OrbotActivity.kt
@@ -320,13 +320,14 @@ class OrbotActivity : BaseActivity() {
         rootLayout?.visibility = View.INVISIBLE
         RequirePasswordPrompt.openPrompt(this, object :
             BiometricPrompt.AuthenticationCallback() {
-            override fun onAuthenticationError(errorCode: Int, errString: CharSequence) {
-                super.onAuthenticationError(errorCode, errString)
-                if (errorCode == BiometricPrompt.ERROR_NO_DEVICE_CREDENTIAL)
-                    Toast.makeText(this@OrbotActivity, R.string.error_no_password_set, Toast.LENGTH_LONG).show()
-                else
-                    finish()
-
+            override fun onAuthenticationError(errorCode: Int, orbotErrorMessage: CharSequence) {
+                super.onAuthenticationError(errorCode, orbotErrorMessage)
+                    Toast.makeText(
+                        this@OrbotActivity,
+                        orbotErrorMessage,
+                        Toast.LENGTH_LONG
+                    ).show()
+                    rootLayout?.visibility = View.VISIBLE
             }
 
             override fun onAuthenticationSucceeded(result: BiometricPrompt.AuthenticationResult) {

--- a/app/src/main/java/org/torproject/android/OrbotActivity.kt
+++ b/app/src/main/java/org/torproject/android/OrbotActivity.kt
@@ -302,7 +302,7 @@ class OrbotActivity : BaseActivity() {
     }
 
     private fun promptDevicePasswordIfRequired() {
-        if (!Prefs.requireDevicePassword())
+        if (!Prefs.requireDeviceAuthentication())
             return
 
         if (!OrbotApp.shouldRequestPasswordReset)

--- a/app/src/main/java/org/torproject/android/OrbotActivity.kt
+++ b/app/src/main/java/org/torproject/android/OrbotActivity.kt
@@ -28,7 +28,7 @@ import androidx.navigation.ui.setupWithNavController
 
 import com.google.android.material.bottomnavigation.BottomNavigationView
 import com.scottyab.rootbeer.RootBeer
-import org.torproject.android.core.makeToast
+import org.torproject.android.core.showToast
 
 import org.torproject.android.core.sendIntentToService
 import org.torproject.android.core.ui.BaseActivity
@@ -327,7 +327,7 @@ class OrbotActivity : BaseActivity() {
                     finish() // user presses back, just close
                 } else if (errorCode == BiometricPrompt.ERROR_HW_UNAVAILABLE) {
                     // we set this flag when Orbot *can't* authenticate, ie no password or unsupported device
-                    makeToast(errorMsg) // String set in RequirePasswordPrompt.kt
+                    showToast(errorMsg) // String set in RequirePasswordPrompt.kt
                     rootLayout?.visibility = View.VISIBLE
                 }
             }

--- a/app/src/main/java/org/torproject/android/OrbotActivity.kt
+++ b/app/src/main/java/org/torproject/android/OrbotActivity.kt
@@ -36,7 +36,6 @@ import org.torproject.android.service.OrbotConstants
 import org.torproject.android.service.util.Prefs
 import org.torproject.android.ui.more.LogBottomSheet
 import org.torproject.android.ui.connect.ConnectViewModel
-import org.torproject.android.util.RequirePasswordPrompt
 import org.torproject.android.util.DeviceAuthenticationPrompt
 
 class OrbotActivity : BaseActivity() {

--- a/app/src/main/java/org/torproject/android/OrbotActivity.kt
+++ b/app/src/main/java/org/torproject/android/OrbotActivity.kt
@@ -323,6 +323,7 @@ class OrbotActivity : BaseActivity() {
             override fun onAuthenticationError(errorCode: Int, errorMsg: CharSequence) {
                 OrbotApp.isAuthenticationPromptOpenLegacyFlag = false
                 if (errorCode == BiometricPrompt.ERROR_USER_CANCELED) {
+                    OrbotApp.resetLockFlags()
                     finish() // user presses back, just close
                 } else if (errorCode == BiometricPrompt.ERROR_HW_UNAVAILABLE) {
                     // we set this flag when Orbot *can't* authenticate, ie no password or unsupported device
@@ -338,8 +339,8 @@ class OrbotActivity : BaseActivity() {
             }
 
             override fun onAuthenticationFailed() {
-                OrbotApp.isAuthenticationPromptOpenLegacyFlag = false
-                this@OrbotActivity.finish()
+                OrbotApp.resetLockFlags()
+                finish()
             }
         })
     }

--- a/app/src/main/java/org/torproject/android/OrbotActivity.kt
+++ b/app/src/main/java/org/torproject/android/OrbotActivity.kt
@@ -28,6 +28,7 @@ import androidx.navigation.ui.setupWithNavController
 
 import com.google.android.material.bottomnavigation.BottomNavigationView
 import com.scottyab.rootbeer.RootBeer
+import org.torproject.android.core.makeToast
 
 import org.torproject.android.core.sendIntentToService
 import org.torproject.android.core.ui.BaseActivity
@@ -320,14 +321,14 @@ class OrbotActivity : BaseActivity() {
         rootLayout?.visibility = View.INVISIBLE
         RequirePasswordPrompt.openPrompt(this, object :
             BiometricPrompt.AuthenticationCallback() {
-            override fun onAuthenticationError(errorCode: Int, orbotErrorMessage: CharSequence) {
-                super.onAuthenticationError(errorCode, orbotErrorMessage)
-                    Toast.makeText(
-                        this@OrbotActivity,
-                        orbotErrorMessage,
-                        Toast.LENGTH_LONG
-                    ).show()
+            override fun onAuthenticationError(errorCode: Int, errorMsg: CharSequence) {
+                if (errorCode == BiometricPrompt.ERROR_USER_CANCELED) {
+                    finish() // user presses back, just close
+                } else if (errorCode == BiometricPrompt.ERROR_HW_UNAVAILABLE) {
+                    // we set this flag when Orbot *can't* authenticate, ie no password or unsupported device
+                    makeToast(errorMsg) // String set in RequirePasswordPrompt.kt
                     rootLayout?.visibility = View.VISIBLE
+                }
             }
 
             override fun onAuthenticationSucceeded(result: BiometricPrompt.AuthenticationResult) {
@@ -336,7 +337,7 @@ class OrbotActivity : BaseActivity() {
             }
 
             override fun onAuthenticationFailed() {
-                finish()
+                this@OrbotActivity.finish()
             }
         })
     }

--- a/app/src/main/java/org/torproject/android/OrbotActivity.kt
+++ b/app/src/main/java/org/torproject/android/OrbotActivity.kt
@@ -37,6 +37,7 @@ import org.torproject.android.service.util.Prefs
 import org.torproject.android.ui.more.LogBottomSheet
 import org.torproject.android.ui.connect.ConnectViewModel
 import org.torproject.android.util.RequirePasswordPrompt
+import org.torproject.android.util.DeviceAuthenticationPrompt
 
 class OrbotActivity : BaseActivity() {
 
@@ -236,7 +237,7 @@ class OrbotActivity : BaseActivity() {
 
     override fun onStart() {
         super.onStart()
-        promptDevicePasswordIfRequired()
+        promptDeviceAuthenticationIfRequired()
     }
 
     override fun onResume() {
@@ -301,16 +302,16 @@ class OrbotActivity : BaseActivity() {
         }
     }
 
-    private fun promptDevicePasswordIfRequired() {
+    private fun promptDeviceAuthenticationIfRequired() {
         if (!Prefs.requireDeviceAuthentication())
             return
 
-        if (!OrbotApp.shouldRequestPasswordReset)
+        if (!OrbotApp.shouldRequestAuthentication)
             return
 
         // if app was closed, we should re-request password upon
         // re-open, even if we've gotten it already
-        OrbotApp.shouldRequestPasswordReset = false
+        OrbotApp.shouldRequestAuthentication = false
 
         if (OrbotApp.isAuthenticationPromptOpenLegacyFlag)
             return
@@ -318,7 +319,7 @@ class OrbotActivity : BaseActivity() {
         OrbotApp.isAuthenticationPromptOpenLegacyFlag = true
 
         rootLayout?.visibility = View.INVISIBLE
-        RequirePasswordPrompt.openPrompt(this, object :
+        DeviceAuthenticationPrompt.openPrompt(this, object :
             BiometricPrompt.AuthenticationCallback() {
             override fun onAuthenticationError(errorCode: Int, errorMsg: CharSequence) {
                 OrbotApp.isAuthenticationPromptOpenLegacyFlag = false
@@ -332,7 +333,7 @@ class OrbotActivity : BaseActivity() {
             }
 
             override fun onAuthenticationSucceeded(result: BiometricPrompt.AuthenticationResult) {
-                OrbotApp.shouldRequestPasswordReset = false
+                OrbotApp.shouldRequestAuthentication = false
                 OrbotApp.isAuthenticationPromptOpenLegacyFlag = false
                 rootLayout?.visibility = View.VISIBLE
             }

--- a/app/src/main/java/org/torproject/android/OrbotApp.kt
+++ b/app/src/main/java/org/torproject/android/OrbotApp.kt
@@ -74,5 +74,9 @@ class OrbotApp : Application() {
         var shouldRequestAuthentication: Boolean = true
         // see https://github.com/guardianproject/orbot-android/issues/1340
         var isAuthenticationPromptOpenLegacyFlag: Boolean = false
+        fun resetLockFlags() {
+            shouldRequestAuthentication = true
+            isAuthenticationPromptOpenLegacyFlag = false
+        }
     }
 }

--- a/app/src/main/java/org/torproject/android/OrbotApp.kt
+++ b/app/src/main/java/org/torproject/android/OrbotApp.kt
@@ -21,7 +21,7 @@ class OrbotApp : Application() {
             override fun onStop(owner: LifecycleOwner) {
                 super.onStop(owner)
                 if (!isAuthenticationPromptOpenLegacyFlag)
-                    shouldRequestPasswordReset = true
+                    shouldRequestAuthentication = true
             }
 
         })
@@ -71,7 +71,7 @@ class OrbotApp : Application() {
     }
 
     companion object {
-        var shouldRequestPasswordReset: Boolean = true
+        var shouldRequestAuthentication: Boolean = true
         // see https://github.com/guardianproject/orbot-android/issues/1340
         var isAuthenticationPromptOpenLegacyFlag: Boolean = false
     }

--- a/app/src/main/java/org/torproject/android/OrbotApp.kt
+++ b/app/src/main/java/org/torproject/android/OrbotApp.kt
@@ -20,8 +20,10 @@ class OrbotApp : Application() {
         ProcessLifecycleOwner.get().lifecycle.addObserver(object : DefaultLifecycleObserver {
             override fun onStop(owner: LifecycleOwner) {
                 super.onStop(owner)
-                shouldRequestPasswordReset = true
+                if (!isAuthenticationPromptOpenLegacyFlag)
+                    shouldRequestPasswordReset = true
             }
+
         })
 
 //      useful for finding unclosed sockets...
@@ -69,6 +71,8 @@ class OrbotApp : Application() {
     }
 
     companion object {
-        var shouldRequestPasswordReset: Boolean = false
+        var shouldRequestPasswordReset: Boolean = true
+        // see https://github.com/guardianproject/orbot-android/issues/1340
+        var isAuthenticationPromptOpenLegacyFlag: Boolean = false
     }
 }

--- a/app/src/main/java/org/torproject/android/ui/more/SettingsPreferenceFragment.kt
+++ b/app/src/main/java/org/torproject/android/ui/more/SettingsPreferenceFragment.kt
@@ -11,6 +11,7 @@ import androidx.preference.CheckBoxPreference
 import androidx.preference.EditTextPreference
 import androidx.preference.ListPreference
 import androidx.preference.Preference
+import androidx.preference.Preference.OnPreferenceChangeListener
 import androidx.preference.PreferenceCategory
 import androidx.preference.PreferenceFragmentCompat
 import org.torproject.android.R
@@ -71,6 +72,24 @@ class SettingsPreferenceFragment : PreferenceFragmentCompat() {
                 replace(R.id.settings_container, CamoFragment())
             }
             true
+        }
+
+        val prefOrbotAuthentication = findPreference<CheckBoxPreference>("pref_require_password")
+        val prefPasswordNoBiometrics = findPreference<CheckBoxPreference>("pref_auth_no_biometrics")
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.R) {
+            prefPasswordNoBiometrics?.isVisible = false
+        } else {
+            prefPasswordNoBiometrics?.isEnabled = prefOrbotAuthentication?.isChecked == true
+            prefOrbotAuthentication?.onPreferenceChangeListener = object : OnPreferenceChangeListener {
+                override fun onPreferenceChange(
+                    preference: Preference,
+                    newValue: Any?
+                ): Boolean {
+                    val b = newValue as Boolean
+                    prefPasswordNoBiometrics?.isEnabled = newValue
+                    return true
+                }
+            }
         }
     }
 

--- a/app/src/main/java/org/torproject/android/util/DeviceAuthenticationPrompt.kt
+++ b/app/src/main/java/org/torproject/android/util/DeviceAuthenticationPrompt.kt
@@ -1,6 +1,5 @@
 package org.torproject.android.util
 
-import android.annotation.SuppressLint
 import android.content.Context
 import android.os.Build
 import androidx.biometric.BiometricManager
@@ -10,9 +9,15 @@ import androidx.fragment.app.FragmentActivity
 import org.torproject.android.R
 import org.torproject.android.service.util.Prefs
 
-class RequirePasswordPrompt {
+class DeviceAuthenticationPrompt {
     companion object {
 
+        /**
+         * Launch a system prompt requiring the user to authenticate their
+         * Android device. On APIs lower than 30, this has to support the password
+         * and biometrics (if user configured them). On 30+, it can be toggled to
+         * disallow biometrics
+         */
         fun openPrompt(
             activity: FragmentActivity,
             callback: BiometricPrompt.AuthenticationCallback
@@ -64,8 +69,10 @@ class RequirePasswordPrompt {
             }
         }
 
-        // when API < 30 you actually need both password and biometrics, so return that
-        // if >= 30, return that unless a preference disallows biometrics
+        /**
+         * Get legal BiometricManager.Authenticators for different versions of Android
+         * if on API 30+ this is configured with a preference, otherwise its hardcoded
+         */
         private fun getAuthenticators(): Int {
             val biometricOrPassword =
                 BiometricManager.Authenticators.DEVICE_CREDENTIAL or BiometricManager.Authenticators.BIOMETRIC_WEAK

--- a/app/src/main/java/org/torproject/android/util/DeviceAuthenticationPrompt.kt
+++ b/app/src/main/java/org/torproject/android/util/DeviceAuthenticationPrompt.kt
@@ -9,80 +9,77 @@ import androidx.fragment.app.FragmentActivity
 import org.torproject.android.R
 import org.torproject.android.service.util.Prefs
 
-class DeviceAuthenticationPrompt {
-    companion object {
-
-        /**
-         * Launch a system prompt requiring the user to authenticate their
-         * Android device. On APIs lower than 30, this has to support the password
-         * and biometrics (if user configured them). On 30+, it can be toggled to
-         * disallow biometrics
-         */
-        fun openPrompt(
-            activity: FragmentActivity,
-            callback: BiometricPrompt.AuthenticationCallback
-        ) {
-            val authenticators = getAuthenticators()
-            // display error for no authentication or system error and abort flow
-            val authenticationErrorCode =
-                BiometricManager.from(activity).canAuthenticate(authenticators)
-            if (authenticationErrorCode != BiometricManager.BIOMETRIC_SUCCESS) {
-                callback.onAuthenticationError(
-                    BiometricPrompt.ERROR_HW_UNAVAILABLE,
-                    getAuthenticationErrorMessage(authenticationErrorCode, activity)
-                )
-                return
-            }
-
-            val appName =
-                if (Prefs.isCamoEnabled()) Prefs.getCamoAppDisplayName() else activity.getString(
-                    R.string.app_name
-                )
-
-            val promptInfo = BiometricPrompt.PromptInfo.Builder()
-                .setConfirmationRequired(true)
-                .setTitle(appName)
-                .setSubtitle(activity.getString(R.string.unlock_app_msg, appName))
-                .setAllowedAuthenticators(authenticators)
-                .build()
-
-            BiometricPrompt(activity, ContextCompat.getMainExecutor(activity), callback)
-                .authenticate(promptInfo)
+object DeviceAuthenticationPrompt {
+    /**
+     * Launch a system prompt requiring the user to authenticate their
+     * Android device. On APIs lower than 30, this has to support the password
+     * and biometrics (if user configured them). On 30+, it can be toggled to
+     * disallow biometrics
+     */
+    fun openPrompt(
+        activity: FragmentActivity,
+        callback: BiometricPrompt.AuthenticationCallback
+    ) {
+        val authenticators = getAuthenticators()
+        // display error for no authentication or system error and abort flow
+        val authenticationErrorCode =
+            BiometricManager.from(activity).canAuthenticate(authenticators)
+        if (authenticationErrorCode != BiometricManager.BIOMETRIC_SUCCESS) {
+            callback.onAuthenticationError(
+                BiometricPrompt.ERROR_HW_UNAVAILABLE,
+                getAuthenticationErrorMessage(authenticationErrorCode, activity)
+            )
+            return
         }
 
-        /**
-         * Returns null if the device is configured to do the authentication prompt
-         * or else a user-facing String indicating that the device is not configured
-         * or otherwise fundamentally unable to authenticate
-         */
-        private fun getAuthenticationErrorMessage(errorCode: Int, context: Context): CharSequence {
-            return when (errorCode) {
-                BiometricManager.BIOMETRIC_SUCCESS -> ""
+        val appName =
+            if (Prefs.isCamoEnabled()) Prefs.getCamoAppDisplayName() else activity.getString(
+                R.string.app_name
+            )
 
-                BiometricManager.BIOMETRIC_ERROR_NONE_ENROLLED ->
-                    context.getString(R.string.error_no_password_set)
+        val promptInfo = BiometricPrompt.PromptInfo.Builder()
+            .setConfirmationRequired(true)
+            .setTitle(appName)
+            .setSubtitle(activity.getString(R.string.unlock_app_msg, appName))
+            .setAllowedAuthenticators(authenticators)
+            .build()
 
-                BiometricManager.BIOMETRIC_ERROR_SECURITY_UPDATE_REQUIRED ->
-                    context.getString(R.string.device_lock_security_update_needed)
+        BiometricPrompt(activity, ContextCompat.getMainExecutor(activity), callback)
+            .authenticate(promptInfo)
+    }
 
-                else -> context.getString(R.string.device_lock_unsupported)
-            }
+    /**
+     * Returns null if the device is configured to do the authentication prompt
+     * or else a user-facing String indicating that the device is not configured
+     * or otherwise fundamentally unable to authenticate
+     */
+    private fun getAuthenticationErrorMessage(errorCode: Int, context: Context): CharSequence {
+        return when (errorCode) {
+            BiometricManager.BIOMETRIC_SUCCESS -> ""
+
+            BiometricManager.BIOMETRIC_ERROR_NONE_ENROLLED ->
+                context.getString(R.string.error_no_password_set)
+
+            BiometricManager.BIOMETRIC_ERROR_SECURITY_UPDATE_REQUIRED ->
+                context.getString(R.string.device_lock_security_update_needed)
+
+            else -> context.getString(R.string.device_lock_unsupported)
         }
+    }
 
-        /**
-         * Get legal BiometricManager.Authenticators for different versions of Android
-         * if on API 30+ this is configured with a preference, otherwise its hardcoded
-         */
-        private fun getAuthenticators(): Int {
-            val biometricOrPassword =
-                BiometricManager.Authenticators.DEVICE_CREDENTIAL or BiometricManager.Authenticators.BIOMETRIC_WEAK
-            if (Build.VERSION.SDK_INT < Build.VERSION_CODES.R) {
-                return biometricOrPassword
-            }
-            return if (Prefs.disallowBiometricAuthentication())
-                BiometricManager.Authenticators.DEVICE_CREDENTIAL
-            else
-                biometricOrPassword
+    /**
+     * Get legal BiometricManager.Authenticators for different versions of Android
+     * if on API 30+ this is configured with a preference, otherwise its hardcoded
+     */
+    private fun getAuthenticators(): Int {
+        val biometricOrPassword =
+            BiometricManager.Authenticators.DEVICE_CREDENTIAL or BiometricManager.Authenticators.BIOMETRIC_WEAK
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.R) {
+            return biometricOrPassword
         }
+        return if (Prefs.disallowBiometricAuthentication())
+            BiometricManager.Authenticators.DEVICE_CREDENTIAL
+        else
+            biometricOrPassword
     }
 }

--- a/app/src/main/java/org/torproject/android/util/RequirePasswordPrompt.kt
+++ b/app/src/main/java/org/torproject/android/util/RequirePasswordPrompt.kt
@@ -1,5 +1,6 @@
 package org.torproject.android.util
 
+import android.annotation.SuppressLint
 import android.content.Context
 import androidx.biometric.BiometricManager
 import androidx.biometric.BiometricPrompt
@@ -22,6 +23,7 @@ class RequirePasswordPrompt {
             // display error for no authentication or system error and abort flow
             val authenticationErrorCode = BiometricManager.from(activity).canAuthenticate(AUTHENTICATORS)
             if (authenticationErrorCode != BiometricManager.BIOMETRIC_SUCCESS) {
+                @SuppressLint("WrongConstant") // we are only using the "right" constants here, from the API...
                 callback.onAuthenticationError(authenticationErrorCode, getAuthenticationErrorMessage(authenticationErrorCode, activity))
                 return
             }

--- a/app/src/main/java/org/torproject/android/util/RequirePasswordPrompt.kt
+++ b/app/src/main/java/org/torproject/android/util/RequirePasswordPrompt.kt
@@ -23,8 +23,7 @@ class RequirePasswordPrompt {
             // display error for no authentication or system error and abort flow
             val authenticationErrorCode = BiometricManager.from(activity).canAuthenticate(AUTHENTICATORS)
             if (authenticationErrorCode != BiometricManager.BIOMETRIC_SUCCESS) {
-                @SuppressLint("WrongConstant") // we are only using the "right" constants here, from the API...
-                callback.onAuthenticationError(authenticationErrorCode, getAuthenticationErrorMessage(authenticationErrorCode, activity))
+                callback.onAuthenticationError(BiometricPrompt.ERROR_HW_UNAVAILABLE, getAuthenticationErrorMessage(authenticationErrorCode, activity))
                 return
             }
 

--- a/app/src/main/java/org/torproject/android/util/RequirePasswordPrompt.kt
+++ b/app/src/main/java/org/torproject/android/util/RequirePasswordPrompt.kt
@@ -1,5 +1,6 @@
 package org.torproject.android.util
 
+import android.content.Context
 import androidx.biometric.BiometricManager
 import androidx.biometric.BiometricPrompt
 import androidx.core.content.ContextCompat
@@ -9,18 +10,55 @@ import org.torproject.android.service.util.Prefs
 
 class RequirePasswordPrompt {
     companion object {
-        fun openPrompt(activity: FragmentActivity, callback: BiometricPrompt.AuthenticationCallback) {
-            val appName = if (Prefs.isCamoEnabled()) Prefs.getCamoAppDisplayName() else activity.getString(
-                R.string.app_name)
+
+        const val AUTHENTICATORS =
+            BiometricManager.Authenticators.DEVICE_CREDENTIAL or BiometricManager.Authenticators.BIOMETRIC_WEAK
+
+        fun openPrompt(
+            activity: FragmentActivity,
+            callback: BiometricPrompt.AuthenticationCallback
+        ) {
+
+            // display error for no authentication or system error and abort flow
+            val authenticationErrorCode = BiometricManager.from(activity).canAuthenticate(AUTHENTICATORS)
+            if (authenticationErrorCode != BiometricManager.BIOMETRIC_SUCCESS) {
+                callback.onAuthenticationError(authenticationErrorCode, getAuthenticationErrorMessage(authenticationErrorCode, activity))
+                return
+            }
+
+            val appName =
+                if (Prefs.isCamoEnabled()) Prefs.getCamoAppDisplayName() else activity.getString(
+                    R.string.app_name
+                )
             val promptInfo = BiometricPrompt.PromptInfo.Builder()
                 .setConfirmationRequired(true)
                 .setTitle(appName)
                 .setSubtitle(activity.getString(R.string.unlock_app_msg, appName))
-                .setAllowedAuthenticators(BiometricManager.Authenticators.DEVICE_CREDENTIAL)
+                .setAllowedAuthenticators(AUTHENTICATORS)
                 .build()
             val prompt =
                 BiometricPrompt(activity, ContextCompat.getMainExecutor(activity), callback)
             prompt.authenticate(promptInfo)
+        }
+
+        /**
+         * Returns null if the device is configured to do the authentication prompt
+         * or else a user-facing String indicating that the device is not configured
+         * or otherwise fundamentally unable to authenticate
+         */
+        private fun getAuthenticationErrorMessage(errorCode: Int, context: Context): CharSequence {
+            return when (errorCode) {
+                BiometricManager.BIOMETRIC_SUCCESS -> ""
+
+                BiometricManager.BIOMETRIC_ERROR_NONE_ENROLLED ->
+                    context.getString(R.string.error_no_password_set)
+
+                BiometricManager.BIOMETRIC_ERROR_SECURITY_UPDATE_REQUIRED ->
+                    context.getString(R.string.device_lock_security_update_needed)
+
+                else -> context.getString(R.string.device_lock_unsupported)
+            }
+
         }
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -304,13 +304,13 @@
     <string name="power_user_mode_permission_msg">Please allow Orbot to set alarms and reminders in order to use power user mode. This won\'t actually set any alarms on your device. This permission is needed to have the system keep OrbotService running when Orbot is not being used as a system-wide VPN.</string>
 
     <string name="pref_require_password">Orbot Authentication</string>
-    <string name="pref_require_password_description">Prevent access to Orbot until you authenticate your device. This can be combined with Camouflage Mode to help hide that Orbot is installed on your device</string>
+    <string name="pref_require_password_description">Prevent access to Orbot until you authenticate by entering your device password or fingerprint. This can be combined with Camouflage Mode to help hide that Orbot is installed on your device</string>
     <string name="error_no_password_set">Please secure your device in order to use Orbot Authentication </string>
     <string name="device_lock_unsupported">Orbot Authentication is not supported on your device</string>
     <string name="device_lock_security_update_needed">You must download Android security updates for your device in order to use Orbot Authentication</string>
-    <string name="unlock_app_msg" formatted="true">Your device password is needed to unlock %s</string>
     <string name="invalid_bridge_format">Invalid bridge format</string>
     <string name="error_asking_tor_for_bridges">Error asking Tor how to connect</string>
+    <string name="unlock_app_msg" formatted="true">Please unlock your device in order to use %s</string>
     <string name="pref_password_only_no_biometric">Disallow Biometrics for Orbot Authentication</string>
-    <string name="pref_password_only_no_biometric_description">This forces Orbot Authentication to only use your device\'s password even if biometric authentication is configured on your device.</string>
+    <string name="pref_password_only_no_biometric_description">This forces Orbot Authentication to only require your device\'s password even if biometric authentication, such as fingerprint or face unlock, are configured on your device.</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -303,9 +303,11 @@
     <string name="power_user_mode_permission">Alarms &amp; Reminders Permission Needed for Power User Mode</string>
     <string name="power_user_mode_permission_msg">Please allow Orbot to set alarms and reminders in order to use power user mode. This won\'t actually set any alarms on your device. This permission is needed to have the system keep OrbotService running when Orbot is not being used as a system-wide VPN.</string>
 
-    <string name="pref_require_password">Device Password Lock</string>
-    <string name="pref_require_password_description">Prevent access to Orbot until you enter your device\'s password. This can be combined with Camouflage Mode to help hide that Orbot is installed on your device</string>
-    <string name="error_no_password_set">Please set a password on your device in order to use Device Password Lock </string>
+    <string name="pref_require_password">Orbot Authentication</string>
+    <string name="pref_require_password_description">Prevent access to Orbot until you authenticate your device. This can be combined with Camouflage Mode to help hide that Orbot is installed on your device</string>
+    <string name="error_no_password_set">Please secure your device in order to use Orbot Authentication </string>
+    <string name="device_lock_unsupported">Orbot Authentication is not supported on your device</string>
+    <string name="device_lock_security_update_needed">You must download Android security updates for your device in order to use Orbot Authentication</string>
     <string name="unlock_app_msg" formatted="true">Your device password is needed to unlock %s</string>
 
     <string name="invalid_bridge_format">Invalid bridge format</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -309,7 +309,8 @@
     <string name="device_lock_unsupported">Orbot Authentication is not supported on your device</string>
     <string name="device_lock_security_update_needed">You must download Android security updates for your device in order to use Orbot Authentication</string>
     <string name="unlock_app_msg" formatted="true">Your device password is needed to unlock %s</string>
-
     <string name="invalid_bridge_format">Invalid bridge format</string>
     <string name="error_asking_tor_for_bridges">Error asking Tor how to connect</string>
+    <string name="pref_password_only_no_biometric">Disallow Biometrics for Orbot Authentication</string>
+    <string name="pref_password_only_no_biometric_description">This forces Orbot Authentication to only use your device\'s password even if biometric authentication is configured on your device.</string>
 </resources>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -77,6 +77,13 @@
             android:defaultValue="false"
             app:iconSpaceReserved="false"/>
 
+        <CheckBoxPreference
+            android:title="@string/pref_password_only_no_biometric"
+            android:summary="@string/pref_password_only_no_biometric_description"
+            android:key="pref_auth_no_biometrics"
+            android:defaultValue="false"
+            app:iconSpaceReserved="false"/>
+
     </PreferenceCategory>
 
     <PreferenceCategory

--- a/appcore/src/main/java/org/torproject/android/core/OrbotExtensionFunctions.kt
+++ b/appcore/src/main/java/org/torproject/android/core/OrbotExtensionFunctions.kt
@@ -44,10 +44,10 @@ fun Context.sendIntentToService(action: String) =
         }
     )
 
-fun Context.makeToast(msg: CharSequence) =
+fun Context.showToast(msg: CharSequence) =
     Toast.makeText(this, msg, Toast.LENGTH_LONG).show()
 
-fun Context.makeToast(@StringRes msgId: Int) =
+fun Context.showToast(@StringRes msgId: Int) =
     Toast.makeText(this, msgId, Toast.LENGTH_LONG).show()
 
 /**

--- a/appcore/src/main/java/org/torproject/android/core/OrbotExtensionFunctions.kt
+++ b/appcore/src/main/java/org/torproject/android/core/OrbotExtensionFunctions.kt
@@ -2,6 +2,8 @@ package org.torproject.android.core
 
 import android.content.Context
 import android.content.Intent
+import android.widget.Toast
+import androidx.annotation.StringRes
 
 import androidx.core.content.ContextCompat
 
@@ -41,6 +43,12 @@ fun Context.sendIntentToService(action: String) =
             this.action = action
         }
     )
+
+fun Context.makeToast(msg: CharSequence) =
+    Toast.makeText(this, msg, Toast.LENGTH_LONG).show()
+
+fun Context.makeToast(@StringRes msgId: Int) =
+    Toast.makeText(this, msgId, Toast.LENGTH_LONG).show()
 
 /**
  * Returns the first key corresponding to the given [value], or `null`

--- a/orbotservice/src/main/java/org/torproject/android/service/util/Prefs.java
+++ b/orbotservice/src/main/java/org/torproject/android/service/util/Prefs.java
@@ -47,6 +47,7 @@ public class Prefs {
     private static final String PREF_CAMO_APP_PACKAGE = "pref_key_camo_app";
     private static final String PREF_CAMO_APP_DISPLAY_NAME = "pref_key_camo_app_display_name";
     private static final String PREF_REQUIRE_PASSWORD = "pref_require_password";
+    private static final String PREF_DISALLOW_BIOMETRIC_AUTH = "pref_auth_no_biometrics";
 
     private static final String PREF_CONNECTION_PATHWAY = "pref_connection_pathway";
     public static final String CONNECTION_PATHWAY_SMART = "smart";
@@ -323,9 +324,14 @@ public class Prefs {
         return prefs.getString(PREF_CAMO_APP_DISPLAY_NAME, "Android");
     }
 
-    public static boolean requireDevicePassword() {
+    public static boolean requireDeviceAuthentication() {
         return prefs.getBoolean(PREF_REQUIRE_PASSWORD, false);
     }
+
+    public static boolean disallowBiometricAuthentication() {
+        return prefs.getBoolean(PREF_DISALLOW_BIOMETRIC_AUTH, false);
+    }
+
 
     public static void setCamoAppDisplayName(String name) {
         putString(PREF_CAMO_APP_DISPLAY_NAME, name);


### PR DESCRIPTION
- Fixes #1325 where the password lock would crash on APIs lower than 30. This is done by forcing biometrics OR password for those devices 
- Nougat, and some other older Androids, would enter a loop with the old code for prompting authentication (once the aforementioned crash was fixed). This fixes #1340  
- Adds a preference on API >= 30 to disallow biometrics, forcing user to only use password 
- Fixes some edge cases where user has no authentication setup 
- Updates UI to be focused more on "Authentication" instead of passwords since biometrics are also now enabled.