### PR TITLE
Add validation support for MeekLite and Vanilla custom bridges

### DIFF
--- a/app/src/main/java/org/torproject/android/ui/connect/CustomBridgeBottomSheet.kt
+++ b/app/src/main/java/org/torproject/android/ui/connect/CustomBridgeBottomSheet.kt
@@ -1,6 +1,8 @@
 package org.torproject.android.ui.connect
 
 import android.app.AlertDialog
+import android.content.res.ColorStateList
+import android.graphics.Color
 import android.os.Bundle
 import android.text.Editable
 import android.text.TextWatcher
@@ -116,7 +118,16 @@ class CustomBridgeBottomSheet(private val callbacks: ConnectionHelperCallbacks) 
 
     private fun updateUi() {
         val inputText = binding.etBridges.text.toString()
-        binding.btnAction.isEnabled = inputText.isNotEmpty() && isValidBridge(inputText)
+        val isValid = inputText.isNotEmpty() && isValidBridge(inputText)
+
+        binding.btnAction.isEnabled = isValid
+        binding.btnAction.backgroundTintList = ColorStateList.valueOf(
+            if (isValid) {
+                requireContext().getColor(R.color.orbot_btn_enabled_purple)
+            } else {
+                Color.DKGRAY
+            }
+        )
 
         if (!isValidBridge(inputText)) {
             binding.etBridges.error = requireContext().getString(R.string.invalid_bridge_format)

--- a/app/src/main/java/org/torproject/android/ui/connect/CustomBridgeBottomSheet.kt
+++ b/app/src/main/java/org/torproject/android/ui/connect/CustomBridgeBottomSheet.kt
@@ -23,9 +23,10 @@ class CustomBridgeBottomSheet(private val callbacks: ConnectionHelperCallbacks) 
 
     companion object {
         const val TAG = "CustomBridgeBottomSheet"
-        private val bridgeStatement = Regex("(obfs4|meek|webtunnel)")
+        private val bridgeStatement = Regex("""(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}|\[[0-9a-fA-F:]+])""")
         private val meekLiteRegex = Regex("""^meek_lite\s+(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}|\[[0-9a-fA-F:]+]):\d+\s+url=https?://\S+\s+front=\S+\s+utls=\S+$""")
         private val obfs4Regex = Regex("""^obfs4\s+(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}|\[[0-9a-fA-F:]+]):\d+\s+[A-F0-9]{40}(\s+cert=[a-zA-Z0-9+/=]+)?(\s+iat-mode=\d+)?$""")
+        private val vanillaRegex = Regex("""(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}|\[[0-9a-fA-F:]+]):\d+\s+[A-F0-9]{40}?$""")
         private val webtunnelRegex = Regex("""^webtunnel\s+(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}|\[[0-9a-fA-F:]+]):\d+\s+[A-F0-9]{40}(\s+url=https?://\S+)?(\s+ver=\d+\.\d+\.\d+)?$""")
 
         fun isValidBridge(input: String): Boolean {
@@ -34,7 +35,8 @@ class CustomBridgeBottomSheet(private val callbacks: ConnectionHelperCallbacks) 
                 .all {
                     it.matches(obfs4Regex) ||
                     it.matches(webtunnelRegex) ||
-                    it.matches(meekLiteRegex)
+                    it.matches(meekLiteRegex) ||
+                    it.matches(vanillaRegex)
                 }
         }
     }

--- a/app/src/main/java/org/torproject/android/ui/connect/CustomBridgeBottomSheet.kt
+++ b/app/src/main/java/org/torproject/android/ui/connect/CustomBridgeBottomSheet.kt
@@ -24,13 +24,18 @@ class CustomBridgeBottomSheet(private val callbacks: ConnectionHelperCallbacks) 
     companion object {
         const val TAG = "CustomBridgeBottomSheet"
         private val bridgeStatement = Regex("(obfs4|meek|webtunnel)")
+        private val meekLiteRegex = Regex("""^meek_lite\s+(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}|\[[0-9a-fA-F:]+]):\d+\s+url=https?://\S+\s+front=\S+\s+utls=\S+$""")
         private val obfs4Regex = Regex("""^obfs4\s+(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}|\[[0-9a-fA-F:]+]):\d+\s+[A-F0-9]{40}(\s+cert=[a-zA-Z0-9+/=]+)?(\s+iat-mode=\d+)?$""")
         private val webtunnelRegex = Regex("""^webtunnel\s+(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}|\[[0-9a-fA-F:]+]):\d+\s+[A-F0-9]{40}(\s+url=https?://\S+)?(\s+ver=\d+\.\d+\.\d+)?$""")
 
         fun isValidBridge(input: String): Boolean {
             return input.lines()
                 .filter { it.isNotEmpty() && it.isNotBlank() }
-                .all { it.matches(obfs4Regex) || it.matches(webtunnelRegex) }
+                .all {
+                    it.matches(obfs4Regex) ||
+                    it.matches(webtunnelRegex) ||
+                    it.matches(meekLiteRegex)
+                }
         }
     }
 

--- a/orbotservice/src/main/java/org/torproject/android/service/circumvention/Transport.kt
+++ b/orbotservice/src/main/java/org/torproject/android/service/circumvention/Transport.kt
@@ -77,6 +77,8 @@ enum class Transport(val id: String) {
             }
         }
 
+        private val validCustomTransport = Regex("(obfs4|meek_lite|webtunnel)")
+
         /**
          * Seems more reliable in certain countries than the currently advertised one.
          */
@@ -99,7 +101,7 @@ enum class Transport(val id: String) {
                 CUSTOM -> {
                     Prefs.bridgesList
                         .mapNotNull { Bridge(it).transport }
-                        .filter { it.isNotBlank() }
+                        .filter { it.isNotBlank() && it.matches(validCustomTransport) }
                         .toSet()
                 }
                 else -> setOf(IPtProxy.Snowflake)

--- a/orbotservice/src/main/java/org/torproject/android/service/circumvention/Transport.kt
+++ b/orbotservice/src/main/java/org/torproject/android/service/circumvention/Transport.kt
@@ -77,8 +77,6 @@ enum class Transport(val id: String) {
             }
         }
 
-        private val validCustomTransport = Regex("(obfs4|meek_lite|webtunnel)")
-
         /**
          * Seems more reliable in certain countries than the currently advertised one.
          */
@@ -101,7 +99,7 @@ enum class Transport(val id: String) {
                 CUSTOM -> {
                     Prefs.bridgesList
                         .mapNotNull { Bridge(it).transport }
-                        .filter { it.isNotBlank() && it.matches(validCustomTransport) }
+                        .filter { it.isNotBlank() }
                         .toSet()
                 }
                 else -> setOf(IPtProxy.Snowflake)


### PR DESCRIPTION
Add regex support for MeekLite and Vanilla custom bridge validation. Tor supports a "vanilla bridge" with `Bridge IP:PORT <FINGERPRINT>` which can be helpful in specific regions.  Also, only enable the "Connect" button for custom bridges after a successful format validation.

Fixes: #1369