### PR TITLE
Fix landscape orientation for tablets

### DIFF
--- a/app/src/main/java/org/torproject/android/ui/core/BaseActivity.kt
+++ b/app/src/main/java/org/torproject/android/ui/core/BaseActivity.kt
@@ -37,7 +37,7 @@ open class BaseActivity : AppCompatActivity() {
         requestedOrientation = if (isTablet) {
             val currentOrientation = resources.configuration.orientation
             val lockedInOrientation =
-                if (currentOrientation == Configuration.ORIENTATION_LANDSCAPE) ActivityInfo.SCREEN_ORIENTATION_LANDSCAPE
+                if (currentOrientation == Configuration.ORIENTATION_LANDSCAPE) ActivityInfo.SCREEN_ORIENTATION_USER_LANDSCAPE
                 else ActivityInfo.SCREEN_ORIENTATION_PORTRAIT
             lockedInOrientation
         } else ActivityInfo.SCREEN_ORIENTATION_PORTRAIT


### PR DESCRIPTION
SCREEN_ORIENTATION_LANDSCAPE always turn screen clockwise. 
However some tablet users might have their screens locked in counterclockwise orientation. 
This situation leads to Orbot activities being locked upside-down. 

SCREEN_ORIENTATION_USER_LANDSCAPE respects the orientation picked by the user. 
Rotation does not trigger restart of the activity.