### PR TITLE
Fixed setting exit node to a specific country.

### DIFF
--- a/app/src/main/java/org/torproject/android/service/OrbotService.java
+++ b/app/src/main/java/org/torproject/android/service/OrbotService.java
@@ -610,7 +610,7 @@ public class OrbotService extends VpnService {
             try {
                 conn.setConf("GeoIPFile", new File(appBinHome, GEOIP_ASSET_KEY).getCanonicalPath());
                 conn.setConf("GeoIPv6File", new File(appBinHome, GEOIP6_ASSET_KEY).getCanonicalPath());
-                conn.setConf("ExitNodes", newExits);
+                conn.setConf("ExitNodes", Prefs.getExitNodes());
                 conn.setConf("StrictNodes", "1");
                 conn.setConf("DisableNetwork", "1");
                 conn.setConf("DisableNetwork", "0");


### PR DESCRIPTION
It seems, setting a specific exit country was broken until now. Only when you restarted would it work, because setting it on start with the Tor config was actually done correctly.

When done on the fly by reconfiguring, the country code would be used like this: 'CC'. However, country codes need to be enclosed in curly braces like this: '{CC}'.

See documentation:
https://2019.www.torproject.org/docs/tor-manual.html.en#ExcludeNodes

Please verify my fix and merge immediately, when ok, @bitmold! Thank you!