### PR TITLE
Run OrbotService and TorService in single process

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -127,18 +127,12 @@
             android:exported="true"
             android:foregroundServiceType="systemExempted"
             android:permission="android.permission.BIND_VPN_SERVICE"
-            android:process=":tor"
             android:stopWithTask="false"
             tools:ignore="VpnServicePolicy">
             <intent-filter>
                 <action android:name="android.net.VpnService" />
             </intent-filter>
         </service>
-
-        <service
-            android:name="org.torproject.jni.TorService"
-            android:process=":tor"
-            tools:node="merge" />
 
         <service
             android:name=".ui.quicksettings.LaunchOrbotTileService"


### PR DESCRIPTION
When using power user mode and not setting battery optimization exemption (may drain the battery), this helps Orbot from being killed by Android for the following reasons:

1. Reduces memory footprint (one process instead of two)
2. Makes the service appear as a single, larger component to the OS
3. Eliminates the overhead of inter-process communication

Android's process killer considers:
- Total memory usage
- Number of active processes
- Process importance (foreground vs background)

By combining:
- You halve the process count
- The unified service can more easily maintain foreground priority
- The OS sees one "important" service rather than two separate ones