### PR TITLE
disable shadowsocks on x86 devices

### DIFF
--- a/app/src/main/java/org/torproject/android/service/OrbotService.java
+++ b/app/src/main/java/org/torproject/android/service/OrbotService.java
@@ -209,9 +209,7 @@ public class OrbotService extends VpnService {
         }
 
         // Stop ShadowSocks client, in case we started it.
-        if (ShadowSocks.isShadowSocksSupported()) {
-            ShadowSocks.stop();
-        }
+        ShadowSocks.stop();
 
         if (shouldUnbindTorService) {
             Log.d(TAG, "unbinding tor service");

--- a/app/src/main/java/org/torproject/android/service/OrbotService.java
+++ b/app/src/main/java/org/torproject/android/service/OrbotService.java
@@ -209,7 +209,9 @@ public class OrbotService extends VpnService {
         }
 
         // Stop ShadowSocks client, in case we started it.
-        ShadowSocks.stop();
+        if (ShadowSocks.isShadowSocksSupported()) {
+            ShadowSocks.stop();
+        }
 
         if (shouldUnbindTorService) {
             Log.d(TAG, "unbinding tor service");

--- a/app/src/main/java/org/torproject/android/service/circumvention/Transport.kt
+++ b/app/src/main/java/org/torproject/android/service/circumvention/Transport.kt
@@ -182,11 +182,11 @@ enum class Transport(val id: String) {
                             }
                         }
 
-                        ShadowSocks.SHADOW_SOCKS_SCHEME -> {
-                            if (ShadowSocks.isShadowSocksSupported()) {
-                                // Start built-in ShadowSocks client.
-                                val address = ShadowSocks.start(context, proxy.toString())
+                        ShadowSocks.SCHEME -> {
+                            // Start built-in ShadowSocks client, if supported.
+                            val address = ShadowSocks.start(context, proxy.toString())
 
+                            if (!address.isNullOrEmpty()) {
                                 // Set local address of ShadowSocks client as proxy.
                                 result.add("Socks5Proxy $address")
                             }
@@ -325,11 +325,13 @@ enum class Transport(val id: String) {
 
                 else -> {
                     // Still need to start ShadowSocks and get the right proxy config.
-                    if (proxy?.scheme == ShadowSocks.SHADOW_SOCKS_SCHEME && ShadowSocks.isShadowSocksSupported()) {
+                    if (proxy?.scheme == ShadowSocks.SCHEME) {
                         val address = ShadowSocks.start(context, proxy.toString())
 
-                        // Since we rewrite `proxy` from `ss://` to `socks5://`, this won't be called again.
-                        proxy = URI("socks5://$address")
+                        if (!address.isNullOrEmpty()) {
+                            // Since we rewrite `proxy` from `ss://` to `socks5://`, this won't be called again.
+                            proxy = URI("socks5://$address")
+                        }
                     }
 
                     // VERY IMPORTANT  we say proxy?.toString() instead of proxy.toString()

--- a/app/src/main/java/org/torproject/android/service/circumvention/Transport.kt
+++ b/app/src/main/java/org/torproject/android/service/circumvention/Transport.kt
@@ -182,12 +182,14 @@ enum class Transport(val id: String) {
                             }
                         }
 
-                        "ss" -> {
-                            // Start built-in ShadowSocks client.
-                            val address = ShadowSocks.start(context, proxy.toString())
+                        ShadowSocks.SHADOW_SOCKS_SCHEME -> {
+                            if (ShadowSocks.isShadowSocksSupported()) {
+                                // Start built-in ShadowSocks client.
+                                val address = ShadowSocks.start(context, proxy.toString())
 
-                            // Set local address of ShadowSocks client as proxy.
-                            result.add("Socks5Proxy $address")
+                                // Set local address of ShadowSocks client as proxy.
+                                result.add("Socks5Proxy $address")
+                            }
                         }
                     }
                 }
@@ -323,7 +325,7 @@ enum class Transport(val id: String) {
 
                 else -> {
                     // Still need to start ShadowSocks and get the right proxy config.
-                    if (proxy?.scheme == "ss") {
+                    if (proxy?.scheme == ShadowSocks.SHADOW_SOCKS_SCHEME && ShadowSocks.isShadowSocksSupported()) {
                         val address = ShadowSocks.start(context, proxy.toString())
 
                         // Since we rewrite `proxy` from `ss://` to `socks5://`, this won't be called again.

--- a/app/src/main/java/org/torproject/android/service/tor/ShadowSocks.kt
+++ b/app/src/main/java/org/torproject/android/service/tor/ShadowSocks.kt
@@ -95,6 +95,6 @@ object ShadowSocks {
 
     @JvmStatic
     fun isShadowSocksSupported(): Boolean {
-        return Build.SUPPORTED_ABIS.firstOrNull()?.equals("x86") == true
+        return Build.SUPPORTED_ABIS.firstOrNull()?.equals("x86") != true
     }
 }

--- a/app/src/main/java/org/torproject/android/service/tor/ShadowSocks.kt
+++ b/app/src/main/java/org/torproject/android/service/tor/ShadowSocks.kt
@@ -46,8 +46,9 @@ object ShadowSocks {
      * as a library.
      */
     @JvmStatic
-    fun start(context: Context, serverUrl: String): String {
-        if (!isShadowSocksSupported()) return ""
+    fun start(context: Context, serverUrl: String): String? {
+        if (!isShadowSocksSupported()) return null
+
         stop()
 
         val file = File(context.applicationInfo.nativeLibraryDir, "libsslocal.so")
@@ -79,7 +80,6 @@ object ShadowSocks {
 
     @JvmStatic
     fun stop() {
-        if (!isShadowSocksSupported()) return
         if (process != null) {
             Log.d("ShadowSocks", "Stop running ShadowSocks client.")
 

--- a/app/src/main/java/org/torproject/android/service/tor/ShadowSocks.kt
+++ b/app/src/main/java/org/torproject/android/service/tor/ShadowSocks.kt
@@ -45,6 +45,7 @@ object ShadowSocks {
      */
     @JvmStatic
     fun start(context: Context, serverUrl: String): String {
+        if (!isShadowSocksSupported()) return ""
         stop()
 
         val file = File(context.applicationInfo.nativeLibraryDir, "libsslocal.so")
@@ -76,17 +77,25 @@ object ShadowSocks {
 
     @JvmStatic
     fun stop() {
+        if (!isShadowSocksSupported()) return
         if (process != null) {
             Log.d("ShadowSocks", "Stop running ShadowSocks client.")
 
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
                 process?.destroyForcibly()
-            }
-            else {
+            } else {
                 process?.destroy()
             }
 
             process = null
         }
     }
+
+    const val SHADOW_SOCKS_SCHEME = "ss"
+
+    @JvmStatic
+    fun isShadowSocksSupported(): Boolean {
+        return Build.SUPPORTED_ABIS.firstOrNull()?.equals("x86") == true
+    }
+
 }

--- a/app/src/main/java/org/torproject/android/service/tor/ShadowSocks.kt
+++ b/app/src/main/java/org/torproject/android/service/tor/ShadowSocks.kt
@@ -37,6 +37,8 @@ import java.net.ServerSocket
  */
 object ShadowSocks {
 
+    const val SCHEME = "ss"
+
     private var process: Process? = null
 
     /**
@@ -91,11 +93,8 @@ object ShadowSocks {
         }
     }
 
-    const val SHADOW_SOCKS_SCHEME = "ss"
-
     @JvmStatic
     fun isShadowSocksSupported(): Boolean {
         return Build.SUPPORTED_ABIS.firstOrNull()?.equals("x86") == true
     }
-
 }

--- a/app/src/main/java/org/torproject/android/ui/more/SettingsPreferenceFragment.kt
+++ b/app/src/main/java/org/torproject/android/ui/more/SettingsPreferenceFragment.kt
@@ -17,7 +17,9 @@ import org.torproject.android.OrbotApp
 import org.torproject.android.R
 import org.torproject.android.localization.Languages
 import org.torproject.android.service.OrbotConstants
+import org.torproject.android.service.tor.ShadowSocks
 import org.torproject.android.util.Prefs
+import org.torproject.android.util.removeEntry
 import org.torproject.android.util.sendIntentToService
 
 class SettingsPreferenceFragment : AbstractPreferenceFragment(), OnPreferenceChangeListener {
@@ -107,6 +109,7 @@ class SettingsPreferenceFragment : AbstractPreferenceFragment(), OnPreferenceCha
             }
 
         val proxyType = findPreference<ListPreference>("pref_proxy_type")
+        if (!ShadowSocks.isShadowSocksSupported()) proxyType?.removeEntry(ShadowSocks.SHADOW_SOCKS_SCHEME)
 
         if (proxyType != null) {
             proxyType.onPreferenceChangeListener = this
@@ -132,10 +135,12 @@ class SettingsPreferenceFragment : AbstractPreferenceFragment(), OnPreferenceCha
                 common.forEach { it.isVisible = false }
                 ssConfig?.isVisible = false
             }
-            "ss" -> {
+
+            ShadowSocks.SHADOW_SOCKS_SCHEME -> {
                 common.forEach { it.isVisible = false }
                 ssConfig?.isVisible = true
             }
+
             else -> {
                 common.forEach { it.isVisible = true }
                 ssConfig?.isVisible = false

--- a/app/src/main/java/org/torproject/android/ui/more/SettingsPreferenceFragment.kt
+++ b/app/src/main/java/org/torproject/android/ui/more/SettingsPreferenceFragment.kt
@@ -109,7 +109,13 @@ class SettingsPreferenceFragment : AbstractPreferenceFragment(), OnPreferenceCha
             }
 
         val proxyType = findPreference<ListPreference>("pref_proxy_type")
-        if (!ShadowSocks.isShadowSocksSupported()) proxyType?.removeEntry(ShadowSocks.SHADOW_SOCKS_SCHEME)
+        if (!ShadowSocks.isShadowSocksSupported()) {
+            proxyType?.removeEntry(ShadowSocks.SCHEME)
+
+            if (proxyType?.value == ShadowSocks.SCHEME) {
+                proxyType.value = ""
+            }
+        }
 
         if (proxyType != null) {
             proxyType.onPreferenceChangeListener = this

--- a/app/src/main/java/org/torproject/android/ui/more/SettingsPreferenceFragment.kt
+++ b/app/src/main/java/org/torproject/android/ui/more/SettingsPreferenceFragment.kt
@@ -136,7 +136,7 @@ class SettingsPreferenceFragment : AbstractPreferenceFragment(), OnPreferenceCha
                 ssConfig?.isVisible = false
             }
 
-            ShadowSocks.SHADOW_SOCKS_SCHEME -> {
+            ShadowSocks.SCHEME -> {
                 common.forEach { it.isVisible = false }
                 ssConfig?.isVisible = true
             }

--- a/app/src/main/java/org/torproject/android/util/OrbotExtensionFunctions.kt
+++ b/app/src/main/java/org/torproject/android/util/OrbotExtensionFunctions.kt
@@ -136,12 +136,15 @@ fun Fragment.haveIBeenDetached(): Boolean {
 }
 
 fun ListPreference.removeEntry(label: String) {
-    val entries = entries?.map { it.toString() }?.toMutableList() ?: return
-    val entryValues = entryValues?.map { it.toString() }?.toMutableList() ?: return
+    val entries = entries?.toMutableList() ?: return
+    val entryValues = entryValues?.toMutableList() ?: return
+
     val index = entryValues.indexOf(label)
     if (index == -1) return
+
     entries.removeAt(index)
     entryValues.removeAt(index)
+
     this.entries = entries.toTypedArray()
     this.entryValues = entryValues.toTypedArray()
 }

--- a/app/src/main/java/org/torproject/android/util/OrbotExtensionFunctions.kt
+++ b/app/src/main/java/org/torproject/android/util/OrbotExtensionFunctions.kt
@@ -17,6 +17,7 @@ import org.torproject.android.service.OrbotConstants
 import org.torproject.android.service.OrbotService
 import java.text.Normalizer
 import androidx.core.net.toUri
+import androidx.preference.ListPreference
 
 /**
  * Extension function for `Intent` to add a flag that marks the intent as originating
@@ -132,4 +133,15 @@ fun Fragment.haveIBeenDetached(): Boolean {
     if (retVal)
         Log.d(javaClass.simpleName, "has been detached on (other) Thread, aborting...")
     return retVal
+}
+
+fun ListPreference.removeEntry(label: String) {
+    val entries = entries?.map { it.toString() }?.toMutableList() ?: return
+    val entryValues = entryValues?.map { it.toString() }?.toMutableList() ?: return
+    val index = entryValues.indexOf(label)
+    if (index == -1) return
+    entries.removeAt(index)
+    entryValues.removeAt(index)
+    this.entries = entries.toTypedArray()
+    this.entryValues = entryValues.toTypedArray()
 }

--- a/app/src/main/java/org/torproject/android/util/Prefs.kt
+++ b/app/src/main/java/org/torproject/android/util/Prefs.kt
@@ -220,7 +220,7 @@ object Prefs {
             val scheme = cr?.getPrefString("pref_proxy_type")?.lowercase()?.trim()
             if (scheme.isNullOrEmpty()) return Pair(null, null)
 
-            if (scheme == ShadowSocks.SHADOW_SOCKS_SCHEME) {
+            if (scheme == ShadowSocks.SCHEME) {
                 val config = cr?.getPrefString("pref_proxy_ss")?.trim()
                 if (config.isNullOrEmpty()) return Pair(null, null)
 

--- a/app/src/main/java/org/torproject/android/util/Prefs.kt
+++ b/app/src/main/java/org/torproject/android/util/Prefs.kt
@@ -7,6 +7,7 @@ import androidx.work.PeriodicWorkRequest
 import androidx.work.WorkManager
 import org.torproject.android.service.OrbotConstants
 import org.torproject.android.service.circumvention.Transport
+import org.torproject.android.service.tor.ShadowSocks
 import java.net.URI
 import java.net.URISyntaxException
 import java.util.Locale
@@ -219,7 +220,7 @@ object Prefs {
             val scheme = cr?.getPrefString("pref_proxy_type")?.lowercase()?.trim()
             if (scheme.isNullOrEmpty()) return Pair(null, null)
 
-            if (scheme == "ss") {
+            if (scheme == ShadowSocks.SHADOW_SOCKS_SCHEME) {
                 val config = cr?.getPrefString("pref_proxy_ss")?.trim()
                 if (config.isNullOrEmpty()) return Pair(null, null)
 

--- a/build_shadowsocks.sh
+++ b/build_shadowsocks.sh
@@ -38,7 +38,7 @@ cd "shadowsocks-android"
 
 echo "- Copy created so files…"
 cp -a core/build/rustJniLibs/android/* "$ROOT/app/src/main/jniLibs/" >> "$LOG" 2>&1
-rm "app/src/main/jniLibs/x86/libsslocal.so"
+rm -rf "$ROOT/app/src/main/jniLibs/x86" >> "$LOG" 2>&1
 echo "- Cleanup…"
 cd "$ROOT"
 rm -rf "$BUILDDIR"

--- a/build_shadowsocks.sh
+++ b/build_shadowsocks.sh
@@ -38,7 +38,7 @@ cd "shadowsocks-android"
 
 echo "- Copy created so files…"
 cp -a core/build/rustJniLibs/android/* "$ROOT/app/src/main/jniLibs/" >> "$LOG" 2>&1
-
+rm "app/src/main/jniLibs/x86/libsslocal.so"
 echo "- Cleanup…"
 cd "$ROOT"
 rm -rf "$BUILDDIR"


### PR DESCRIPTION
As discussed, this removes the shadowsocks binary on x86 (32 bit intel CPUs) which are effectively just android emulators with 64 bit Intel hosts emulating very old versions of Android. 

It removes the value from the UI, which should invalidate all ShadowSocks flows, but still, the wrapper and code around it aren't called if you're on a 32 bit Intel device.

I also changed all the String literals for `"ss"` into a constnat, in case anyone accidentally mistypes a character unknowingly, the program compiles, but something breaks. 