### PR TITLE
Orbot UI boot fix 1713

### DIFF
--- a/app/src/main/java/org/torproject/android/OrbotActivity.kt
+++ b/app/src/main/java/org/torproject/android/OrbotActivity.kt
@@ -26,7 +26,6 @@ import androidx.navigation.ui.setupWithNavController
 import com.google.android.material.bottomnavigation.BottomNavigationView
 import com.scottyab.rootbeer.RootBeer
 import org.torproject.android.service.OrbotConstants
-import org.torproject.android.ui.connect.ConnectUiState
 import org.torproject.android.ui.connect.ConnectViewModel
 import org.torproject.android.ui.connect.RequestPostNotificationPermission
 import org.torproject.android.ui.core.BaseActivity
@@ -46,8 +45,6 @@ class OrbotActivity : BaseActivity() {
 
     var portSocks: Int = -1
     var portHttp: Int = -1
-
-    var previousReceivedTorStatus: String? = null
 
     // used to hide UI while password isn't obtained
     private var rootLayout: View? = null
@@ -69,8 +66,6 @@ class OrbotActivity : BaseActivity() {
                 window.decorView.systemUiVisibility and View.SYSTEM_UI_FLAG_LIGHT_STATUS_BAR.inv()
         }
 
-        previousReceivedTorStatus = savedInstanceState?.getString(KEY_TOR_STATUS)
-
         // programmatically set title to "Orbot" since camo mode will overwrite it here from manifest
         title = getString(R.string.app_name)
 
@@ -83,16 +78,6 @@ class OrbotActivity : BaseActivity() {
             intent = null
             finish()
         }
-    }
-
-    override fun onSaveInstanceState(outState: Bundle) {
-        outState.putString(KEY_TOR_STATUS, previousReceivedTorStatus)
-        super.onSaveInstanceState(outState)
-    }
-
-    override fun onRestoreInstanceState(savedInstanceState: Bundle) {
-        super.onRestoreInstanceState(savedInstanceState)
-        previousReceivedTorStatus = savedInstanceState.getString(KEY_TOR_STATUS)
     }
 
     private fun createOrbot() {
@@ -233,9 +218,14 @@ class OrbotActivity : BaseActivity() {
     override fun onResume() {
         super.onResume()
 
-        if (connectViewModel.uiState.value == ConnectUiState.On) {
-            sendIntentToService(OrbotConstants.CMD_ACTIVE)
-        }
+        /**
+         * When OrbotService gets CMD_ACTIVE it:
+         * 1. Checks if the control part is open & tor is connected:
+         *   1a. If true, sends tor the "ACTIVE" signal over the control port
+         * 2. OrbotService replies back to OrbotActivity with its status, regardless of step 1
+         */
+        sendIntentToService(OrbotConstants.CMD_ACTIVE)
+
 
         if (Prefs.beSnowflakeProxy()) {
             SnowflakeProxyService.startSnowflakeProxyForegroundService(this)
@@ -262,10 +252,7 @@ class OrbotActivity : BaseActivity() {
             val status = intent?.getStringExtra(TorService.EXTRA_STATUS)
             when (intent?.action) {
                 OrbotConstants.LOCAL_ACTION_STATUS -> {
-                    if (status != previousReceivedTorStatus) {
-                        connectViewModel.updateState(this@OrbotActivity, status)
-                        previousReceivedTorStatus = status
-                    }
+                    connectViewModel.updateState(this@OrbotActivity, status)
                 }
 
                 OrbotConstants.LOCAL_ACTION_LOG -> {

--- a/app/src/main/java/org/torproject/android/ui/connect/ConnectFragment.kt
+++ b/app/src/main/java/org/torproject/android/ui/connect/ConnectFragment.kt
@@ -200,9 +200,7 @@ class ConnectFragment : Fragment(),
 
 
     // starts Tor, plus often the VPNService. For power users it runs tor as a proxy
-    fun startTorConnection() {
-        setState(TorService.ACTION_START)
-    }
+    fun startTorConnection() = setState(TorService.ACTION_START)
 
     fun attemptToStartTor() {
         Prefs.putUseVpn(!Prefs.isPowerUserMode)


### PR DESCRIPTION
When Orbot started on boot, its UI wouldn't get updated since a few releases 

From #1713 @syphyr says:
> @bitmold I think this started to happen when Orbot changed the way it detects if Tor is connected (which included changes to the tor-android library).

I could reproduce this behavior starting Orbot on boot and noticing that even though Tor bootstrapped fine in the notifications, & that I could use the VPN to reach tor, vut the UI was locked out of sync it's Off state...

This PR does the following: 
- Totally removes the parts `OrbotActivity` from tracking `TorStatus` status in the variable `previousReceivedTorStatus: String?`. From many years ago, before `OrbotActivity`was using a view model and was rewritten in Kotlin, this variable would make sure we weren't over-updating the UI due to some buggy thing in OrbotService. This stuff makes no sense now that `OrbotActivity` *actually* uses a view model, not to mention that `OrbotService` has changed a lot in those many years.
- 
- In `OrbotActivity`'s `onResume()` **_always send CMD_ACTIVE to OrbotService_** instead of just doing it when OrbotActivity's view model is set to `On`. `OrbotService` replies with Tor's status, causing the UI to update - fixing the bug. Theres no risk in sending `CMD_ACTIVE` here. If Tor isn't running, `OrbotService` will just gently reply with its status, and not do anything dangerous. 

- _also accidentally commited a lint thing that I thought was on another branch :woman_shrugging:_


This seems to be working great. But would especially appreciate a few eys on this @n8fr8 @tladesignz @syphyr since it deals with the foundational relationship between `OrbotActivity` and `OrbotService` the whole app's built on. 