### PR TITLE
for #1112 removed unused no network autosleep pref

### DIFF
--- a/app/src/main/java/org/torproject/android/ui/v3onionservice/OnionServiceActivity.java
+++ b/app/src/main/java/org/torproject/android/ui/v3onionservice/OnionServiceActivity.java
@@ -51,7 +51,7 @@ public class OnionServiceActivity extends BaseActivity {
 
         mLayoutRoot = findViewById(R.id.hostedServiceCoordinatorLayout);
         fab = findViewById(R.id.fab);
-        fab.setOnClickListener(v -> new OnionServiceCreateDialogFragment().show(getSupportFragmentManager(), OnionServiceCreateDialogFragment.class.getSimpleName()));
+        fab.setOnClickListener(_ -> new OnionServiceCreateDialogFragment().show(getSupportFragmentManager(), OnionServiceCreateDialogFragment.class.getSimpleName()));
 
         mContentResolver = getContentResolver();
         mAdapter = new OnionV3ListAdapter(this, mContentResolver.query(OnionServiceContentProvider.CONTENT_URI, OnionServiceColumns.getV3_ONION_SERVICE_PROJECTION(), BASE_WHERE_SELECTION_CLAUSE + '1', null, null));
@@ -66,7 +66,7 @@ public class OnionServiceActivity extends BaseActivity {
         else radioShowAppServices.setChecked(true);
         filterServices(showUserServices);
         onionList.setAdapter(mAdapter);
-        onionList.setOnItemClickListener((parent, view, position, id) -> {
+        onionList.setOnItemClickListener((parent, _, position, _) -> {
             Cursor item = (Cursor) parent.getItemAtPosition(position);
             Bundle arguments = new Bundle();
             arguments.putInt(BUNDLE_KEY_ID, item.getInt(item.getColumnIndex(OnionServiceColumns._ID)));

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -52,8 +52,6 @@
     <string name="project_home">الشاشة الرئيسية للمشروع:</string>
     <string name="third_party_software">برامج من الطرف الثالث:</string>
     <string name="set_locale_title">اللغة</string>
-    <string name="pref_disable_network_title">لاتوجد شبكة نوم-آلي</string>
-    <string name="pref_disable_network_summary">ضع تور في وضعية النوم عند عدم وجود الأنترنت</string>
     <string name="newnym">لقد حولت إلى هوية تور جديدة!</string>
     <string name="pref_socks_title">تور SOCKS</string>
     <string name="pref_socks_summary">المنفذ الذي يقدم عليه تور وسيط SOCKS الخاص به (الافتراضي: 9050 أو 0 لتعطيله)</string>

--- a/app/src/main/res/values-ay/strings.xml
+++ b/app/src/main/res/values-ay/strings.xml
@@ -55,8 +55,6 @@
     <string name="hidden_service_request">Tor llikar %1$s waythapiwjanx mä aplikasyunaw mä siwulla yanapir
 \njist\'arañ muni. Ukar atinistax jark\'aqatawa.</string>
     <string name="set_locale_title">Aru</string>
-    <string name="pref_disable_network_title">Jan jiwt\'ayas suyt\'aña</string>
-    <string name="pref_disable_network_summary">Llika jan uktjki ukjax Tor suyt\'ayam</string>
     <string name="newnym">¡Jichhax Tor sutimax yaqhäxiwa!</string>
     <string name="pref_socks_title">Toran SOCKS ukapa</string>
     <string name="pref_socks_summary">Waythapiwja kawkïrxaruti Torax proxy SOCKS ukap churañ muni: (utt\'ayata: jiwt\'ayañatakix 9050 jan ukax 0)</string>

--- a/app/src/main/res/values-az/strings.xml
+++ b/app/src/main/res/values-az/strings.xml
@@ -44,8 +44,6 @@
     <string name="project_home">Layihə Evi:</string>
     <string name="third_party_software">Xidməti Quraşdırma:</string>
     <string name="set_locale_title">Dil</string>
-    <string name="pref_disable_network_title">Avto-Yuxu Şəbəkəsi Yoxdur</string>
-    <string name="pref_disable_network_summary">İnternet olmadıqda icazə ver Tor yatsın</string>
     <string name="newnym">Yeni Tor oxşarına qoşuldun!</string>
     <string name="pref_socks_title">Tor SOCKS</string>
     <string name="pref_socks_summary">Torun təklif etdiyi Port SOCKS proksi işləyir (standart: 9050, yaxud söndürmək üçün 0) </string>

--- a/app/src/main/res/values-be/strings.xml
+++ b/app/src/main/res/values-be/strings.xml
@@ -54,8 +54,6 @@
     <string name="third_party_software">Праграмы іншых распрацоўнікаў: </string>
     <string name="hidden_service_request">Дадатак хоча адкрыць схаваны порт сервера %1$s сеткі Tor. Гэта бяспечна, калі вы давяраеце дадзенаму дадатку.</string>
     <string name="set_locale_title">Мова</string>
-    <string name="pref_disable_network_title">Аўтазасынанне без сеткі</string>
-    <string name="pref_disable_network_summary">Пераводзіць Tor у спячы рэжым пры немені інтэрнэту</string>
     <string name="newnym">Вы перамкнуліся на новы ідэнтыфікатар Tor!</string>
     <string name="pref_socks_title">Tor SOCKS</string>
     <string name="pref_socks_summary">Порт, на якім Tor прапануе свой SOCKS-проксі (па змаўчанні: 9050, 0 - для адключэння)</string>

--- a/app/src/main/res/values-bg/strings.xml
+++ b/app/src/main/res/values-bg/strings.xml
@@ -44,8 +44,6 @@
     <string name="project_home">Станица на проекта:</string>
     <string name="third_party_software">Софтуер от трети страни:</string>
     <string name="set_locale_title">Език</string>
-    <string name="pref_disable_network_title">Без автоматично заспиване на мрежата</string>
-    <string name="pref_disable_network_summary">При липса на интернет Тор преминава в режим на сън</string>
     <string name="newnym">Сменихте самоличността си в Тор!</string>
     <string name="pref_socks_title">SOCKS на Тор</string>
     <string name="pref_socks_summary">Порт, на който Тор предлага прокси на SOCKS (подразбиран: 9050 или 0 за изключване)</string>

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -46,8 +46,6 @@
     <string name="third_party_software">Programari de terceres parts:</string>
     <string name="hidden_service_request">Una aplicació vol obrir el port %1$s del servidor onion a la xarxa Tor. Això és segur si confieu en l\'aplicació.</string>
     <string name="set_locale_title">Llengua</string>
-    <string name="pref_disable_network_title">No hi ha autodesconnexió de xarxa</string>
-    <string name="pref_disable_network_summary">Posa el Tor en pausa mentre no hi ha connexió a internet</string>
     <string name="newnym">Heu canviat a una nova identitat Tor!</string>
     <string name="pref_socks_title">SOCKS del Tor</string>
     <string name="pref_socks_summary">Port al qual el Tor ofereix el seu servidor intermediari SOCKS (per defecte: 9050, o 0 per a desactivar)</string>

--- a/app/src/main/res/values-cs-rCZ/strings.xml
+++ b/app/src/main/res/values-cs-rCZ/strings.xml
@@ -44,8 +44,6 @@
     <string name="project_home">Projekt Domů:</string>
     <string name="third_party_software">Software třetích stran:</string>
     <string name="set_locale_title">Jazyk</string>
-    <string name="pref_disable_network_title">Vypnout uspávání sítě</string>
-    <string name="pref_disable_network_summary">Uspat Tor když není k dispozici přístup k Internetu</string>
     <string name="newnym">Vaše identita na Toru byla změněna!</string>
     <string name="pref_socks_title">Tor SOCKS</string>
     <string name="pref_socks_summary">Port, na kterém Tor nabízí SOCKS proxy (default: 9050, 0 pro zakázání)</string>

--- a/app/src/main/res/values-cy/strings.xml
+++ b/app/src/main/res/values-cy/strings.xml
@@ -57,7 +57,6 @@
     <string name="pref_socks_summary">Porthladd y mae Tor yn cynnig ei ddirprwy SOCKS arno (diofyn: 9050 neu 0 i\'w analluogi)</string>
     <string name="enable_debug_log_to_output_must_use_adb_or_alogcat_to_view_">Galluogi log dadfygio i allbwn (rhaid defnyddio adb neu aLogcat i weld)</string>
     <string name="run_as_a_client_behind_a_firewall_with_restrictive_policies">Rhedeg fel cleient y tu ôl i wal dân gyda pholisïau cyfyngol</string>
-    <string name="pref_disable_network_title">Dim Rhwydwaith Auto-Cwsg</string>
     <string name="hidden_service_request">Mae ap eisiau agor gweinydd winwnsyn ar borth %1$s i rwydwaith Tor. Mae hyn yn ddiogel os ydych chi\'n ymddiried yn yr app.</string>
     <string name="fingerprints_nicks_countries_and_addresses_to_exclude">Olion bysedd, nicks, gwledydd a chyfeiriadau i\'w heithrio</string>
     <string name="newnym">Rydych chi wedi newid i hunaniaeth Tor newydd!</string>
@@ -67,7 +66,6 @@
     <string name="pref_open_proxy_on_all_interfaces_title">Agor Dirprwy ar Bob Rhyngwyneb</string>
     <string name="pref_open_proxy_on_all_interfaces_summary">Caniatáu i gyfoedion Wi-Fi, dyfeisiau clymu ac unrhyw un arall sy\'n gallu cysylltu â\'ch IP, gael mynediad i Tor</string>
     <string name="strict_nodes_description">Trin gosodiadau Nodau Eithrio fel gofyniad ar gyfer adeiladu pob cylched. Gall hyn dorri ymarferoldeb os nad oes modd cynhyrchu unrhyw gylchedau gyda\'ch gosodiadau Nodau Eithrio.</string>
-    <string name="pref_disable_network_summary">Rhowch Tor i gysgu pan nad oes rhyngrwyd ar gael</string>
     <string name="reachable_ports">Porthladdoedd cyraeddadwy</string>
     <string name="reachable_addresses">Cyfeiriadau Cyrraeddadwy</string>
     <string name="pref_circuit_padding">Padin cylched</string>

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -86,9 +86,7 @@
     <string name="hidden_service_request">En app ønsker at åbne en løgserver på port %1$s til Tor-netværket. Dette er sikkert, hvis du stoler på appen.</string>
     <string name="menu_new_identity">Ny identitet</string>
     <string name="strict_nodes_description">Behandl indstillingerne for udelukkelse af knuder som et krav for at opbygge alle kredsløb. Dette kan ødelægge funktionaliteten, hvis der ikke kan genereres kredsløb med dine indstillinger for udelukkede knuder.</string>
-    <string name="pref_disable_network_title">Ingen automatisk netværkssøvn</string>
     <string name="pref_open_proxy_on_all_interfaces_title">Åbn proxy på alle grænseflader</string>
-    <string name="pref_disable_network_summary">Sæt Tor i dvale, når der ikke er internet til rådighed</string>
     <string name="local_port">Lokal havn</string>
     <string name="newnym">Du har skiftet til en ny Tor-identitet!</string>
     <string name="pref_open_proxy_on_all_interfaces_summary">Tillad Wi-Fi-peers, tethered enheder og alle andre, der kan oprette forbindelse til din IP, at få adgang til Tor</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -54,8 +54,6 @@
     <string name="third_party_software">Drittanbieteranwendungen:</string>
     <string name="hidden_service_request">Eine App möchte den Onion-Server auf Port %1$s zum Tor-Netzwerk öffnen. Dies ist sicher, wenn du der App vertraust.</string>
     <string name="set_locale_title">Sprache</string>
-    <string name="pref_disable_network_title">Kein Automatischer Netzwerk-Ruhezustand</string>
-    <string name="pref_disable_network_summary">Tor in den Ruhezustand versetzen, wenn kein Internet verfügbar ist</string>
     <string name="newnym">Du hast zu einer neuen Tor-Identität gewechselt!</string>
     <string name="pref_socks_title">Tor-SOCKS</string>
     <string name="pref_socks_summary">Port, der den SOCKS-Proxy von Tor bereitstellt (Standard: 9050 oder 0, um ihn zu deaktivieren)</string>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -54,8 +54,6 @@
     <string name="third_party_software">Λογισμικό τρίτων:</string>
     <string name="hidden_service_request">Μια εφαρμογή θέλει να ανοίξει διακομιστή onion στη θύρα %1$s στο δίκτυο Tor. Αυτό είναι ασφαλές αν εμπιστεύεστε την εφαρμογή.</string>
     <string name="set_locale_title">Γλώσσα </string>
-    <string name="pref_disable_network_title">Χωρίς Αυτόματη Αναστολή Δικτύου</string>
-    <string name="pref_disable_network_summary">Θέσε το Tor σε λειτουργία sleep όταν δεν υπάρχει διαθέσιμη σύνδεση Ιnternet</string>
     <string name="newnym">Έχετε αλλάξει επιτυχώς την ταυτότητα σας στο Tor! </string>
     <string name="pref_socks_title">Tor SOCKS</string>
     <string name="pref_socks_summary">Θύρα που προσφέρει ο Tor στο SOCKS proxy του (προεπιλογή: 9050 ή 0 για απενεργοποίηση)</string>

--- a/app/src/main/res/values-en-rGB/strings.xml
+++ b/app/src/main/res/values-en-rGB/strings.xml
@@ -59,7 +59,6 @@
     <string name="pref_proxy_type_summary">Proxy server protocol</string>
     <string name="pref_proxy_host_title">Outbound Proxy Host</string>
     <string name="enter_exclude_nodes">Enter Exclude Nodes</string>
-    <string name="pref_disable_network_title">No Network Auto-Sleep</string>
     <string name="v3_backup_key_warning">Warning: This could expose your key to other apps</string>
     <string name="pref_reduced_connection_padding_summary">Closes relay connections sooner and sends less padding packets to reduce data and battery usage</string>
     <string name="pref_proxy_username_summary">Proxy Username (Optional)</string>
@@ -134,7 +133,6 @@
     <string name="backup_restored">Backup restored</string>
     <string name="backup_port_exist">Error: An Onion service is already using port %s</string>
     <string name="service_type">Service type</string>
-    <string name="pref_disable_network_summary">Put Tor to sleep when there is no internet available</string>
     <string name="newnym">You\'ve switched to a new Tor identity!</string>
     <string name="pref_open_proxy_on_all_interfaces_summary">Allow Wi-Fi peers, tethered devices and anyone else who can connect to your IP, to access Tor</string>
     <string name="pref_socks_summary">Port that Tor offers its SOCKS proxy on (default: 9050 or 0 to disable)</string>

--- a/app/src/main/res/values-es-rCU/strings.xml
+++ b/app/src/main/res/values-es-rCU/strings.xml
@@ -64,7 +64,6 @@
     <string name="pref_dnsport_title">Puerto DNS de Tor</string>
     <string name="pref_dnsport_summary">Puerto por el cual Tor ofrece su conexión DNS (por defecto: 9053 o 0 para inhabilitar)</string>
     <string name="pref_dnsport_dialog">Configuración del puerto DNS</string>
-    <string name="pref_disable_network_summary">Desactivar Tor cuando no hay internet disponible</string>
     <string name="newnym">¡Has cambiado a una nueva identidad Tor!</string>
     <string name="pref_http_summary">Puerto por el cual Tor ofrece su conexión proxy HTTP (por defecto: 8118 o 0 para inhabilitar)</string>
     <string name="pref_torrc_title">Configuración Personalizada de Torrc</string>
@@ -74,7 +73,6 @@
     <string name="pref_isolate_protocol">Aislar protocolos de cliente</string>
     <string name="hidden_service_request">Una aplicación quiere abrir el servidor de Onion en el puerto %1$s hacia la red Tor. Esto es seguro solo si confías en la aplicación.</string>
     <string name="set_locale_title">Idioma</string>
-    <string name="pref_disable_network_title">Desactivar auto-suspensión de Red</string>
     <string name="pref_open_proxy_on_all_interfaces_title">Abrir Proxy en todas las interfaces</string>
     <string name="pref_open_proxy_on_all_interfaces_summary">Permitir que los pares Wi-Fi, dispositivos anclados y cualquiera que pueda conectarse a tu IP, accedan a Tor</string>
     <string name="pref_socks_title">Tor SOCKS</string>

--- a/app/src/main/res/values-es-rES/strings.xml
+++ b/app/src/main/res/values-es-rES/strings.xml
@@ -46,8 +46,6 @@
     <string name="third_party_software">Software de terceros:</string>
     <string name="hidden_service_request">Una aplicación quiere abrir un servidor cebolla en el puerto %1$s a la red Tor. Esto es seguro si confías en la aplicación.</string>
     <string name="set_locale_title">Idioma</string>
-    <string name="pref_disable_network_title">Sin suspensión-automática de la red</string>
-    <string name="pref_disable_network_summary">PonTor en suspensión cuando no haya Internet disponible</string>
     <string name="newnym">¡Has cambiado a una nueva identidad de Tor!</string>
     <string name="pref_socks_title">SOCKS de Tor</string>
     <string name="pref_socks_summary">Puerto sobre el que Tor ofrece tu proxy SOCKS (por defecto: 9050 o 0 para deshabilitarlo)</string>

--- a/app/src/main/res/values-es-rMX/strings.xml
+++ b/app/src/main/res/values-es-rMX/strings.xml
@@ -63,7 +63,6 @@
     <string name="btn_change_exit">Cambiar salida</string>
     <string name="pref_circuit_padding_summary">Habilita el relleno de circuito para defenderte contra algunas formas de análisis de tráfico</string>
     <string name="pref_reduced_circuit_padding_summary">Usa algoritmos de relleno de gastos generales más bajos para reducir el uso de datos y batería</string>
-    <string name="pref_disable_network_summary">Pon Tor a dormir cuando no haya Internet disponible</string>
     <string name="pref_open_proxy_on_all_interfaces_summary">Permite que las personas conectadas al mismo Wi-Fi, los dispositivos conectados y cualquier otra persona que pueda conectarse a tu IP acceda a Tor</string>
     <string name="direct_connect_subtitle">La mejor manera de conectarse a Tor. Usar si Tor no está bloqueado.</string>
     <string name="app_suggested_subtitle">Orbot funciona mejor con aplicaciones de mensajería y redes sociales.</string>
@@ -83,7 +82,6 @@
     <string name="enable_debug_log_to_output_must_use_adb_or_alogcat_to_view_">Habilita el registro de depuración para la salida (debes usar adb o aLogcat para verlo)</string>
     <string name="project_home">Inicio del Proyecto:</string>
     <string name="set_locale_title">Idioma</string>
-    <string name="pref_disable_network_title">Sin Conexion Suspensión automática</string>
     <string name="pref_open_proxy_on_all_interfaces_title">Proxy abierto en todas las interfaces</string>
     <string name="pref_socks_title">Tor SOCKS</string>
     <string name="pref_socks_summary">Puerto en el que Tor ofrece tu proxy SOCKS (predeterminado: 9050 o 0 para deshabilitar)</string>

--- a/app/src/main/res/values-et/strings.xml
+++ b/app/src/main/res/values-et/strings.xml
@@ -41,8 +41,6 @@
     <string name="enable_debug_log_to_output_must_use_adb_or_alogcat_to_view_">lubage väljastatav silumislogi (vaatamiseks peab kasutama kas adb või aLogCat utiliite) </string>
     <string name="project_home">Projekti kodu:</string>
     <string name="third_party_software">Kolmanda osapoole tarkvara:</string>
-    <string name="pref_disable_network_title">Pole võrgu auto-und</string>
-    <string name="pref_disable_network_summary">Pane Tor magama kui Internetiühendus puudub</string>
     <string name="newnym">Lülitusite uuele Tor identiteedile!</string>
     <string name="save">Salvesta</string>
     <string name="name">Name</string>

--- a/app/src/main/res/values-eu/strings.xml
+++ b/app/src/main/res/values-eu/strings.xml
@@ -46,8 +46,6 @@
     <string name="third_party_software">Hirugarrengoen softwarea:</string>
     <string name="hidden_service_request">Aplikazio batek ezkutuko zerbitzariko %1$s ataka ireki nau du Tor sarera. Segurua da aplikazioaz fidatzen bazara.</string>
     <string name="set_locale_title">Hizkuntza</string>
-    <string name="pref_disable_network_title">Sareko lokartze automatikorik ez</string>
-    <string name="pref_disable_network_summary">Jarri Tor lotan internet atzigarri ez dagoenean</string>
     <string name="newnym">Tor identitate berri batera aldatu duzu!</string>
     <string name="pref_socks_title">Tor SOCKS</string>
     <string name="pref_socks_summary">Tor-ek bere SOCKS proxya eskaintzeko ataka (Lehenetsia: 9050 edo 0 desgaitzeko)</string>

--- a/app/src/main/res/values-fa/strings.xml
+++ b/app/src/main/res/values-fa/strings.xml
@@ -46,8 +46,6 @@
     <string name="third_party_software">نرم‌افزارهای شخص ثالث:</string>
     <string name="hidden_service_request">برنامه‌ای می‌خواهد سرور Onion روی درگاه ‎%1$s را به شبکهٔ Tor باز کند. اگر به برنامه اعتماد دارید، این کار ایمن است.</string>
     <string name="set_locale_title">زبان</string>
-    <string name="pref_disable_network_title">حالت خواب خودکار درصورت عدم وجود شبکه</string>
-    <string name="pref_disable_network_summary">هنگامی که اینترنت در دسترس نیست، Tor را در حالت خواب قرار می‌دهد</string>
     <string name="newnym">شما به یک هویت Tor جدید تغییر یافته‌اید!</string>
     <string name="pref_socks_title">SOCKS‌های Tor</string>
     <string name="pref_socks_summary">درگاهی که Tor پراکسی SOCKS خود را روی آن ارائه می‌دهد (پیش‌فرض: ۹۰۵۰ یا اینکه ۰ برای غیرفعال‌سازی)</string>

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -44,8 +44,6 @@
     <string name="project_home">Projektin kotisivusto:</string>
     <string name="third_party_software">3. osapuolen ohjelmistot:</string>
     <string name="set_locale_title">Kieli</string>
-    <string name="pref_disable_network_title">Ei verkon automaattilepotilaa</string>
-    <string name="pref_disable_network_summary">Aseta Tor lepotilaan, kun Internet-yhteyttä ei ole käytettävissä.</string>
     <string name="newnym">Vaihdoit Tor-identiteettisi uuteen!</string>
     <string name="pref_socks_title">Tor SOCKS-välityspalvelin</string>
     <string name="pref_socks_summary">Portti, jonka kautta Torin SOCKS-välityspalvelin on tavoitettavissa (oletus on 9050 tai pois käytöstä arvolla 0).</string>

--- a/app/src/main/res/values-fr-rFR/strings.xml
+++ b/app/src/main/res/values-fr-rFR/strings.xml
@@ -44,8 +44,6 @@
     <string name="project_home">Page d’accueil du projet :</string>
     <string name="third_party_software">Logiciels tiers :</string>
     <string name="set_locale_title">Langue</string>
-    <string name="pref_disable_network_title">Aucune mise en veille automatique du réseau</string>
-    <string name="pref_disable_network_summary">Mettre Tor en veille quand Internet est inaccessible</string>
     <string name="newnym">Vous avez basculé vers une nouvelle identité Tor</string>
     <string name="pref_socks_title">SOCKS Tor</string>
     <string name="pref_socks_summary">Port sur lequel Tor offre son mandataire SOCKS (par défaut : 9050 ou 0 pour le désactiver)</string>

--- a/app/src/main/res/values-ga/strings.xml
+++ b/app/src/main/res/values-ga/strings.xml
@@ -50,8 +50,6 @@
     <string name="license">Ceadúnas:</string>
     <string name="hidden_service_request">Tá aip ag iarraidh freastalaí onion a oscailt ar phort %1$s chuig líonra Tor. Tá sé seo sábháilte má tá muinín agat as an aip.</string>
     <string name="set_locale_title">Teanga</string>
-    <string name="pref_disable_network_title">Gan Uathchodladh Líonra</string>
-    <string name="pref_disable_network_summary">Cuir Tor a chodladh nuair nach bhfuil aon idirlíon ar fáil</string>
     <string name="newnym">Tá tú tar éis aistriú go céannacht Tor nua!</string>
     <string name="pref_open_proxy_on_all_interfaces_title">Oscail Seachfhreastalaí ar Gach Comhéadan</string>
     <string name="pref_open_proxy_on_all_interfaces_summary">Ceadaigh piaraí Wi-Fi, gléasanna ceangailte agus aon duine eile ar féidir leo ceangal le do sheoladh IP rochtain a fháil ar Tor</string>

--- a/app/src/main/res/values-gl/strings.xml
+++ b/app/src/main/res/values-gl/strings.xml
@@ -46,8 +46,6 @@
     <string name="third_party_software">Software de Terceiros:</string>
     <string name="hidden_service_request">Unha aplicación quere abrir o porto oculto de servidor %1$s a rede Tor. Esto é seguro se vostede confía na app.</string>
     <string name="set_locale_title">Idioma</string>
-    <string name="pref_disable_network_title">Auto-Parado Sen Rede</string>
-    <string name="pref_disable_network_summary">Parar Tor cando non hai conexión a internet</string>
     <string name="newnym">Cambiou a unha nova identidade Tor!</string>
     <string name="pref_socks_title">SOCKS de Tor</string>
     <string name="pref_socks_summary">Porto no que Tor ofrece o seu proxy SOCKS (por omisión: 9050 ou 0 para desactivar)</string>

--- a/app/src/main/res/values-guc/strings.xml
+++ b/app/src/main/res/values-guc/strings.xml
@@ -49,8 +49,6 @@
   <string name="license">Jiat\'tapula Anaiwua  Puyataya</string>
   <string name="hidden_service_request">Wane app ajútales cewolla, %1$saner jutuma maka pirrajulee</string>
     <string name="set_locale_title">Anuiki</string>
-  <string name="pref_disable_network_title">Nojots atunku\'in  Network jumuiwuaya\'a </string>
-  <string name="pref_disable_network_summary">Púitaa  Tor  junain atunkaa nojotpaa ein internet.</string>
   <string name="newnym">¡tü puanajun sülü wanee jeketü shiyawase Tor!</string>
   <string name="pref_open_proxy_on_all_interfaces_title">Errutnuinjat proxy julu jupushuaya interface</string>
   <string name="pref_open_proxy_on_all_interfaces_summary">Jüputirrein tüpiamaka WI -FI je tü cachuerrakaluirrua, painjirrain, je tü wayukaleirrua eka ein, painjirrain jünain sü IP nekerrotuin nunain Tor</string>

--- a/app/src/main/res/values-gum/strings.xml
+++ b/app/src/main/res/values-gum/strings.xml
@@ -51,8 +51,6 @@
   <string name="license">Utɵ miek</string>
   <string name="hidden_service_request">1%1$s Kan marampurukuntrapik, cebolla wam lasrpichapik Toryu. Ikwane ñi marampurukuntrapikwan tap purukuntraptik kuik asha mar.</string>
     <string name="set_locale_title">Wam-mera</string>
-  <string name="pref_disable_network_title">Wam srɵl mera nɵmtɵpe chincha pasram pumumik</string>
-  <string name="pref_disable_network_summary">Internet kapene Torwan Kiptrasr</string>
   <string name="newnym">Tor maik kenamisrɵpik kuipe yunɵmaran</string>
   <string name="pref_open_proxy_on_all_interfaces_title">Proxy wam latrpichipelan chiutɵmerayu kɵpen kuriklɵ</string>
   <string name="pref_open_proxy_on_all_interfaces_summary">Wifimerayu, wam purɵrɵpelan, trukutri mumeran kɵpen Ipyu kepintrai ɵ teik, Toryu kepiamik</string>

--- a/app/src/main/res/values-hi/strings.xml
+++ b/app/src/main/res/values-hi/strings.xml
@@ -54,8 +54,6 @@
     <string name="third_party_software">दूसरे लोगों का सॉफ्टवेयर:</string>
     <string name="hidden_service_request">एक ऐप टॉर नेटवर्क के लिए %1$s पोर्ट पे अनियन सर्वर खोलना चाहता है। अगर आप ऐप पर भरोसा करते हैं, तो ये महफूज़ है।</string>
     <string name="set_locale_title">भाषा</string>
-    <string name="pref_disable_network_title">कोई नेटवर्क अपनेआप नहीं सोएगा</string>
-    <string name="pref_disable_network_summary">कोई इंटरनेट मौजूद नहीं होने पे टॉर को सुला दें</string>
     <string name="newnym">आपने अपने टॉर पहचान को बदल दिया है!</string>
     <string name="pref_socks_title">टॉर सॉक्स</string>
     <string name="pref_socks_summary">वो पोर्ट जिसपे टॉर अपनी सॉक्स प्रॉक्सी देता है (डिफॉल्ट: 9050 या 0 बंद करने के लिए )</string>

--- a/app/src/main/res/values-hr-rHR/strings.xml
+++ b/app/src/main/res/values-hr-rHR/strings.xml
@@ -52,8 +52,6 @@
     <string name="project_home">Dom(ovi) Projekta:</string>
     <string name="third_party_software">Software treće strane:</string>
     <string name="set_locale_title">Jezik</string>
-    <string name="pref_disable_network_title">Nema mrežnog auto-spavanja</string>
-    <string name="pref_disable_network_summary">Stavi Tor na spavanje kad internet nije dostupan</string>
     <string name="newnym">Prebacili ste se na nov Tor identitet!</string>
     <string name="pref_socks_title">Tor SOCKS</string>
     <string name="pref_socks_summary">Port na kojem Tor pruža svoj SOCKS proxy (zadano: 9050, 0 za onemogućavanje)</string>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -46,8 +46,6 @@
     <string name="third_party_software">3. fél szoftver:</string>
     <string name="hidden_service_request">Egy app egy rejtett szerver portot %1$d nyitna a Tor hálózatra. Ez biztonságos, ha megbízik az appban.</string>
     <string name="set_locale_title">Nyelv</string>
-    <string name="pref_disable_network_title">Nincs hálózati auto-alvás</string>
-    <string name="pref_disable_network_summary">A Tor alvó módba helyezése, ha internet nem elérhető</string>
     <string name="newnym">Új Tor identitásra váltottál!</string>
     <string name="pref_socks_title">Tor SOCKS</string>
     <string name="pref_socks_summary">Port amelyen a Tor a SOCKS proxyt biztosítja (alapértelmezett: 9050 vagy 0 a tiltáshoz)</string>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -44,8 +44,6 @@
     <string name="project_home">Beranda Proyek:</string>
     <string name="third_party_software">Perangkat Lunak Pihak Ke-3:</string>
     <string name="set_locale_title">Bahasa</string>
-    <string name="pref_disable_network_title">Auto-Tidur Tidak Ada Jaringan</string>
-    <string name="pref_disable_network_summary">Menempatkan Tor untuk tidur ketika tidak ada internet yang tersedia</string>
     <string name="newnym">Anda telah beralih ke identitas Tor baru!</string>
     <string name="pref_socks_title">SOCKS Tor</string>
     <string name="pref_socks_summary">Port tempat proxy SOCKS Tor aktif (standar: 9050 atau 0 untuk mematikan)</string>

--- a/app/src/main/res/values-is/strings.xml
+++ b/app/src/main/res/values-is/strings.xml
@@ -46,8 +46,6 @@
     <string name="third_party_software">Hugbúnaður frá 3ja aðila:</string>
     <string name="hidden_service_request">Forrit vill opna onion-netþjón á gáttinni %1$s inn á Tor-netið. Þetta er öruggt ef þú treystir forritinu.</string>
     <string name="set_locale_title">Tungumál</string>
-    <string name="pref_disable_network_title">Engin sjálfvirk svæfing netkerfis</string>
-    <string name="pref_disable_network_summary">Svæfa Tor þegar engin internettenging er til staðar</string>
     <string name="newnym">Þú ert komin með nýtt Tor-auðkenni!</string>
     <string name="pref_socks_title">Tor SOCKS</string>
     <string name="pref_socks_summary">Gátt sem Tor býður SOCKS milliþjón á (sjálfgefið: 9050 eða 0 til að gera óvirkt)</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -46,8 +46,6 @@
     <string name="third_party_software">Software di terze parti:</string>
     <string name="hidden_service_request">Un\'app vuole aprire unserver nascosto sulla porta %1$s verso la rete Tor. È un\'azione sicura se ti fidi dell\'app.</string>
     <string name="set_locale_title">Lingua</string>
-    <string name="pref_disable_network_title">Evita autosospensione della rete</string>
-    <string name="pref_disable_network_summary">Sospendi Tor quando internet non è disponibile</string>
     <string name="newnym">Sei passato a una nuova identità Tor!</string>
     <string name="pref_socks_title">SOCKS di Tor</string>
     <string name="pref_socks_summary">Porta su cui Tor offre il proxy SOCKS (predefinita: 9050 o 0 per disattivare)</string>

--- a/app/src/main/res/values-iw/strings.xml
+++ b/app/src/main/res/values-iw/strings.xml
@@ -45,7 +45,6 @@
     <string name="project_home">אתר המיזם:</string>
     <string name="third_party_software">תוכנת-צד-ג׳:</string>
     <string name="set_locale_title">שפה</string>
-    <string name="pref_disable_network_summary">כיבוי Tor כאשר אין חיבור לאינטרנט</string>
     <string name="newnym">החלפת לזהות Tor חדשה!</string>
     <string name="pref_socks_title">Tor SOCKS</string>
     <string name="pref_socks_dialog">הגדרות פתחת SOCKS</string>
@@ -62,7 +61,6 @@
     <string name="btn_refresh">ריענון החיבור</string>
     <string name="connect">התחברות</string>
     <string name="title_choose_apps">בחירת יישומונים</string>
-    <string name="pref_disable_network_title">שינה אוטומטית כשאין רשת</string>
     <string name="pref_open_proxy_on_all_interfaces_title">פתיחת מתווך על כל הממשקים</string>
     <string name="pref_open_proxy_on_all_interfaces_summary">לאפשר לעמיתים ברשת האלחוטית, מכשירים קשורים ולכל אחד אחר שיכול להתחבר ל־IP שלך לגשת לTor</string>
     <string name="pref_socks_summary">פתחה דרכה Tor מגיש את מתווך ה־SOCKS שלו (ברירת מחדל: 9050 או 0 להשבתה)</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -46,8 +46,6 @@
     <string name="third_party_software">サードパーティ製ソフトウェア:</string>
     <string name="hidden_service_request">アプリが Tor ネットワークへポート %1$s 上にオニオンサーバー開放しようとしています。信頼できるアプリであれば、これは安全です。</string>
     <string name="set_locale_title">言語</string>
-    <string name="pref_disable_network_title">ネットワークがなければ自動スリープする</string>
-    <string name="pref_disable_network_summary">利用可能なインターネット接続がない時、Tor をスリープさせる</string>
     <string name="newnym">新たな Tor 識別子に切り替えました！</string>
     <string name="pref_socks_title">Tor SOCKS</string>
     <string name="pref_socks_summary">Tor が SOCKS プロキシーを提供するポート (初期設定: 9050、0 にすると無効)</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -44,8 +44,6 @@
     <string name="project_home">프로젝트 홈 페이지:</string>
     <string name="third_party_software">3rd-Party-Software: </string>
     <string name="set_locale_title">언어</string>
-    <string name="pref_disable_network_title">네트워크가 없을 때의 자동 슬립</string>
-    <string name="pref_disable_network_summary">인터넷이 불가능하다면 Tor를 슬립 모드로 두십시오</string>
     <string name="newnym">새로운 Tor 신원으로 전환되었습니다!</string>
     <string name="pref_socks_title">토르 SOCKS</string>
     <string name="pref_socks_summary">SOCKS 프록시를 받을 포트 (기본: 9050 / 0은 비활성화)</string>

--- a/app/src/main/res/values-lt-rLT/strings.xml
+++ b/app/src/main/res/values-lt-rLT/strings.xml
@@ -19,7 +19,6 @@
     <string name="backup_port_exist">Klaida: „Onion Service“ jau naudoja prievadą %s</string>
     <string name="name">Pavadinimas</string>
     <string name="v3_hosted_services">Prieglobos „Onion“ paslaugos</string>
-    <string name="pref_disable_network_title">Išjungti tinklo automatinio užmigdymo funkciją</string>
     <string name="run_as_a_client_behind_a_firewall_with_restrictive_policies">Veikti kaip klientui už ugniasienės su ribojančia politika</string>
     <string name="pref_proxy_host_title">Išeinantis įgaliotojo serverio priegloba</string>
     <string name="pref_proxy_host_summary">Įgaliotojo serverio prieglobos vardas</string>
@@ -98,7 +97,6 @@
     <string name="newnym">Jūs perėjote prie naujos „Tor“ tapatybės!</string>
     <string name="v3_backup_key_warning">Įspėjimas: Tai gali atskleisti jūsų raktą kitoms programėlėms</string>
     <string name="pref_node_configuration_summary">Tai yra išplėstiniai nustatymai, kurie gali sumažinti jūsų anonimiškumą</string>
-    <string name="pref_disable_network_summary">Užmigdyti „Tor“, kai nėra interneto</string>
     <string name="pref_proxy_type_summary">Protokolas, kurį reikia naudoti įgaliotajam serveriui</string>
     <string name="pref_allow_background_starts_summary">Leiskite bet kuriai programėlei nurodyti „Orbot“ paleisti „Tor“ ir susijusias paslaugas</string>
     <string name="pref_start_boot_summary">Automatiškai paleisti „Orbot“ ir prijunkti „Tor“, kai įsijungs „Android“ įrenginys</string>

--- a/app/src/main/res/values-lv/strings.xml
+++ b/app/src/main/res/values-lv/strings.xml
@@ -44,8 +44,6 @@
     <string name="project_home">Projekts Home:</string>
     <string name="third_party_software">Trešo personu programmatūra:</string>
     <string name="set_locale_title">Valoda</string>
-    <string name="pref_disable_network_title">Neizmantot tīkla automātiskā miega režīmu</string>
-    <string name="pref_disable_network_summary">Kad nav interneta, pārslēgt Tor\'u uz miega režīmu</string>
     <string name="newnym">Jūs pārslēdzāties uz jaunu Tor\'a identitāti!</string>
     <string name="pref_socks_title">Tor SOCKS</string>
     <string name="pref_socks_summary">Ports, uz kura Tor piedāvā savu SOCKS starpniekserveri (noklusējumvērtība: 9050 vai 0 lai atspējotu)</string>

--- a/app/src/main/res/values-mk/strings.xml
+++ b/app/src/main/res/values-mk/strings.xml
@@ -46,8 +46,6 @@
     <string name="third_party_software">Софтвер од производител од 3-та страна:</string>
     <string name="hidden_service_request">Апликација сака да отвори сокриена серверска порта %1$s кон Tor мрежата. Ова е безбедно доколку и верувате на апликацијата.</string>
     <string name="set_locale_title">Јазик</string>
-    <string name="pref_disable_network_title">Нема Автоматско-спиење на мрежата</string>
-    <string name="pref_disable_network_summary">Ставете го Тор на режим на спиење кога Интернетот не е достапен</string>
     <string name="newnym">Се префрливте на нов идентитет на Tor!</string>
     <string name="pref_socks_title">Tor SOCKS</string>
     <string name="pref_socks_summary">Порта на која Тор и го нуди својот SOCKS-прокси (стандардно: 9050 или 0 за да се исклучи)</string>

--- a/app/src/main/res/values-nah/strings.xml
+++ b/app/src/main/res/values-nah/strings.xml
@@ -49,8 +49,6 @@
     <string name="license">Temacahuiliztli:</string>
     <string name="hidden_service_request">Ce tepoztlatlatquitl quinequi quitlapoz ce itetlayecolti xonacatl ipan tzalantli %1$s matlatl Tor. ¿Ticticuauhtlamati in tepoztlatlatquitl?</string>
     <string name="set_locale_title">Tlahtolcopa</string>
-    <string name="pref_disable_network_title">Ahmo quitlilana in motlapololtia cemtlalticpamatlatl</string>
-    <string name="pref_disable_network_summary">Xiquihtoz Tor ma cochiz ihcuac ahmo onca centilnonotza</string>
     <string name="newnym">¡Axan tiyancuitlacauh ica Tor!</string>
     <string name="pref_open_proxy_on_all_interfaces_title">Xictlapoa ipan nochi cetiliztli</string>
     <string name="pref_open_proxy_on_all_interfaces_summary">Xiccahua in omtlamantli Wi-Fi, in tepozcetililoni oquincelihqueh ihuan cequi tlacah huel quicetilia IP calaqui ipan Tor</string>

--- a/app/src/main/res/values-nb/strings.xml
+++ b/app/src/main/res/values-nb/strings.xml
@@ -44,8 +44,6 @@
     <string name="project_home">Prosjekt Hjem:</string>
     <string name="third_party_software">Tredjepartsprogramvare:</string>
     <string name="set_locale_title">Språk</string>
-    <string name="pref_disable_network_title">Inget automatisk hvilemodus for nettverk</string>
-    <string name="pref_disable_network_summary">Legg Tor i hvilemodus når nettilkobling til Internett ikke er tilgjengelig</string>
     <string name="newnym">Du har byttet til en ny Tor-identitet!</string>
     <string name="pref_socks_title">Tor-SOCKS</string>
     <string name="pref_socks_summary">Port som Tor tilbyr er SOCKS proxy på (standard: 9050 eller 0 for å slå av)</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -54,8 +54,6 @@
     <string name="third_party_software">Software van 3e partijen: </string>
     <string name="hidden_service_request">Een app wil de verborgenserverpoort %1$s tot het Tor-netwerk openen. Dit is veilig als je de app vertrouwt.</string>
     <string name="set_locale_title">Taal</string>
-    <string name="pref_disable_network_title">Geen netwerk automatisch slapen</string>
-    <string name="pref_disable_network_summary">Laat Tor slapen als er geen internetverbinding beschikbaar is</string>
     <string name="newnym">Je bent naar een nieuwe Tor identiteit gewisseld!</string>
     <string name="pref_socks_title">Tor SOCKS</string>
     <string name="pref_socks_summary">Poort waarop Tor de SOCKS-proxy aanbiedt (standaard: 9050 of 0 om uit te schakelen)</string>

--- a/app/src/main/res/values-pbb/strings.xml
+++ b/app/src/main/res/values-pbb/strings.xml
@@ -49,8 +49,6 @@
     <string name="license">Licencia:</string>
     <string name="hidden_service_request">Teeꞔx appekh çaam pe’pe Onion yasesa’s phadewẽje, %1$s vxitxte. naayu’ ewna napa idx ewna sũuteçxaa.</string>
     <string name="set_locale_title">Kĩh yuwe</string>
-    <string name="pref_disable_network_title">Reda’s peetx kyuju’jnximee</string>
-    <string name="pref_disable_network_summary">Tora’s  mikyuju’ internet meete’</string>
     <string name="newnym">¡U’se yaseg yu’pthe! </string>
     <string name="pref_open_proxy_on_all_interfaces_title">Mphade Proxi’s jxukatey</string>
     <string name="pref_open_proxy_on_all_interfaces_summary">Çaam WIFIte açya’ ewuusa’ ki’ maa nasama’k IPte açya ewuuna’ Torte peetx u’kakan miinvxiht</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -44,8 +44,6 @@
     <string name="project_home">Strona główna projektu:</string>
     <string name="third_party_software">Oprogramowanie innych firm:</string>
     <string name="set_locale_title">Język</string>
-    <string name="pref_disable_network_title">Brak automatycznego uśpienia sieci</string>
-    <string name="pref_disable_network_summary">Uśpij Tor, gdy nie ma dostępnego Internetu</string>
     <string name="newnym">Nowa tożsamość Tor została zmieniona!</string>
     <string name="pref_socks_title">SOCKS Tor</string>
     <string name="pref_socks_summary">Port, na którym Tor oferuje swoje proxy SOCKS (domyślnie: 9050 lub 0, aby wyłączyć)</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -54,8 +54,6 @@
     <string name="third_party_software">Software de Terceiros:</string>
     <string name="hidden_service_request">Um aplicativo quer abrir uma porta no servidor onion %1$s para a rede Tor. É seguro caso você confie neste aplicativo.</string>
     <string name="set_locale_title">Idioma</string>
-    <string name="pref_disable_network_title">Sem rede. Modo de Espera Automático</string>
-    <string name="pref_disable_network_summary">Colocar o Tor em modo de espera quando não houver Internet disponível</string>
     <string name="newnym">Você trocou para uma nova identidade Tor!</string>
     <string name="pref_socks_title">Tor SOCKS</string>
     <string name="pref_socks_summary">Porta que o Tor oferece do seu proxy SOCKS (padrão: 9050 ou 0 para desativar)</string>

--- a/app/src/main/res/values-pt-rPT/strings.xml
+++ b/app/src/main/res/values-pt-rPT/strings.xml
@@ -92,8 +92,6 @@
     <string name="pref_transport_title">Porta TransProxy Tor</string>
     <string name="pref_socks_dialog">Configuração da Porta SOCKS</string>
     <string name="pref_socks_summary">Porta que o Tor oferece do proxy SOCKS dele (predefinição: 9050 ou 0 para desativar)</string>
-    <string name="pref_disable_network_summary">Pôr o Tor em modo de latência quando não houver Internet disponível</string>
-    <string name="pref_disable_network_title">Sem Rede, Modo de Latência Automática</string>
     <string name="hidden_service_request">Uma app quer abrir uma porta no servidor onion %1$s para a rede Tor. É seguro caso confie nesta app.</string>
     <string name="enable_debug_log_to_output_must_use_adb_or_alogcat_to_view_">Ativar os registos de depuração para saída (deve usar adb ou aLogCat para ver)</string>
     <string name="run_as_a_client_behind_a_firewall_with_restrictive_policies">Executar como um cliente atrás de um firewall com políticas restritivas</string>

--- a/app/src/main/res/values-ro-rRO/strings.xml
+++ b/app/src/main/res/values-ro-rRO/strings.xml
@@ -52,8 +52,6 @@
     <string name="project_home">Casa(le) proiectului:</string>
     <string name="third_party_software">Aplicatii tertiare:</string>
     <string name="set_locale_title">Limbă</string>
-    <string name="pref_disable_network_title">Fără adormirea automată a rețelei</string>
-    <string name="pref_disable_network_summary">Pune Tor să doarmă dacă nu este internet disponibil</string>
     <string name="newnym">Ați comutat la o nouă identitate Tor!</string>
     <string name="pref_socks_title">Tor SOCKS</string>
     <string name="pref_socks_summary">Porturi pe care Tor oferă SOCKurile proxy active (principal:9050 sau 0 pentru dezactivare)</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -46,8 +46,6 @@
     <string name="third_party_software">Программы сторонних разработчиков: </string>
     <string name="hidden_service_request">Приложение хочет открыть onion-сервер на порту %1$s в сети Tor. Это безопасно, если вы доверяете приложению.</string>
     <string name="set_locale_title">Язык</string>
-    <string name="pref_disable_network_title">Автозасыпание без сети</string>
-    <string name="pref_disable_network_summary">Переводить Tor в спящий режим при отсутствии интернета</string>
     <string name="newnym">Вы переключились на новый идентификатор Tor!</string>
     <string name="pref_socks_title">Tor SOCKS</string>
     <string name="pref_socks_summary">Порт, на котором Tor предоставляет свой SOCKS-прокси (по умолчанию: 9050, 0 — для отключения)</string>

--- a/app/src/main/res/values-sk-rSK/strings.xml
+++ b/app/src/main/res/values-sk-rSK/strings.xml
@@ -69,8 +69,6 @@
     <string name="strict_nodes_description">Nastavenie Vylúčiť uzly považujte za požiadavku na vytvorenie všetkých okruhov. To môže narušiť funkčnosť, ak sa s nastaveniami Exclude Nodes (Vylúčené uzly) nepodarí vygenerovať žiadne obvody.</string>
     <string name="pref_transport_summary">Port, na ktorom Tor ponúka svoj transparentný proxy server (predvolené: 9040 alebo 0 pre vypnutie)</string>
     <string name="set_locale_title">Jazyk</string>
-    <string name="pref_disable_network_title">Žiadny automatický spánok siete</string>
-    <string name="pref_disable_network_summary">Uspanie Tor, keď nie je k dispozícii internet</string>
     <string name="newnym">Prešli ste na novú identitu Tor!</string>
     <string name="pref_open_proxy_on_all_interfaces_title">Otvoriť proxy server na všetkých rozhraniach</string>
     <string name="pref_socks_title">Tor SOCKS</string>

--- a/app/src/main/res/values-sl/strings.xml
+++ b/app/src/main/res/values-sl/strings.xml
@@ -69,8 +69,6 @@
     <string name="pref_node_configuration">Konfiguracija vozlišča</string>
     <string name="strict_nodes_description">Nastavitve Izključi vozlišča obravnavajte kot zahtevo za izgradnjo vseh vezij. To lahko prekine funkcionalnost, če z vašimi nastavitvami Exclude Nodes ni mogoče ustvariti nobenega vezja.</string>
     <string name="pref_socks_title">Tor SOCKS</string>
-    <string name="pref_disable_network_title">Brez samodejnega spanja v omrežju</string>
-    <string name="pref_disable_network_summary">Uspavati Tor, ko ni na voljo interneta</string>
     <string name="newnym">Preklopili ste na novo identiteto Tor!</string>
     <string name="pref_open_proxy_on_all_interfaces_title">Odprt proxy na vseh vmesnikih</string>
     <string name="pref_socks_summary">Vrata, na katerih Tor ponuja svoj posredniški strežnik SOCKS (privzeto: 9050 ali 0 za onemogočanje)</string>

--- a/app/src/main/res/values-sq/strings.xml
+++ b/app/src/main/res/values-sq/strings.xml
@@ -21,7 +21,6 @@
     <string name="backup_restored">Kopjeruajtja u rikthye</string>
     <string name="disable">Çaktivizoje</string>
     <string name="enable">Aktivizoje</string>
-    <string name="pref_disable_network_summary">Vëre në gjumë Tor-in, kur s’ka internet</string>
     <string name="pref_transport_dialog">Formësim Porte</string>
     <string name="pref_torrc_dialog">Torrc vetjake</string>
     <string name="title_choose_apps">Zgjidhni Aplikacione</string>
@@ -128,7 +127,6 @@
     <string name="ports_reachable_behind_a_restrictive_firewall">Porta të kapshme pas një firewall-i kufizues</string>
     <string name="enable_debug_log_to_output_must_use_adb_or_alogcat_to_view_">Aktivizo regjistër diagnostikimi te ç’jepet (duhet përdorur adb ose aLogcat për ta parë)</string>
     <string name="hidden_service_request">Një aplikacion dëshiron të hapë shërbyes onion te porta %1$s për te rrjeti Tor. Kjo është e parrezik, nëse i zini besë aplikacionit.</string>
-    <string name="pref_disable_network_title">Pa Vetë-Fjetje Rrjeti</string>
     <string name="pref_prefer_ipv6_summary">U thotë daljeve se parapëlqehen adresa IPv6</string>
     <string name="pref_transport_summary">Portë te e cila Tor-i ofron Ndërmjetësin e vet Transparent (parazgjedhje: 9040, ose 0 për ta çaktivizuar)</string>
     <string name="pref_torrc_summary">VETËM PËR TË SPROVUARIT: jepni drejtpërsëdrejti rreshta formësimi torrc</string>

--- a/app/src/main/res/values-sr/strings.xml
+++ b/app/src/main/res/values-sr/strings.xml
@@ -46,8 +46,6 @@
     <string name="third_party_software">Софтвер од стране неслужбених издавача:</string>
     <string name="hidden_service_request">Апликација жели да отвори сакривен порт%1$s на серверу за Тор мрежу. Ово је сигуран потез уколико верујете апликацији.</string>
     <string name="set_locale_title">Језик</string>
-    <string name="pref_disable_network_title">Без Мреже Auto-Sleep</string>
-    <string name="pref_disable_network_summary">Умири Тор када је недоступан интернет</string>
     <string name="newnym">Прешли сте на нови Тор идентитет!</string>
     <string name="pref_socks_title">Toр SOCKS</string>
     <string name="pref_socks_summary">Port који Тор нуди је SOCKS прокси укључен (уобичајено: 9050 или 0 за искључивање)</string>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -46,8 +46,6 @@
     <string name="third_party_software">Tredjepartsprogramvara:</string>
     <string name="hidden_service_request">En app vill öppna dold serverport %1$s till Tor-nätverket. Det här är säkert om du litar på appen.</string>
     <string name="set_locale_title">Språk</string>
-    <string name="pref_disable_network_title">Ingen auto-sömn för nätverket</string>
-    <string name="pref_disable_network_summary">Låt Tor sova när inget internet finns tillgängligt</string>
     <string name="newnym">Du har bytt till en ny Tor identitet!</string>
     <string name="pref_socks_title">Tor-SOCKS</string>
     <string name="pref_socks_summary">Port som Tor erbjuder sin SOCKS-proxy på (standard: 9050 eller 0 för att inaktivera)</string>

--- a/app/src/main/res/values-ta/strings.xml
+++ b/app/src/main/res/values-ta/strings.xml
@@ -68,7 +68,6 @@
     <string name="snowflake">ச்னோஃப்ளேக்</string>
     <string name="ask_tor">டோர் கேளுங்கள்</string>
     <string name="many_ways">டோர் ஐ அடைய பல வழிகள் உள்ளன. சிலர் உங்களுக்காக மற்றவர்களைவிடச் சிறப்பாகச் செயல்படக்கூடும்.</string>
-    <string name="pref_disable_network_title">பிணையம் ஆட்டோ ச்லீப் இல்லை</string>
     <string name="pref_socks_summary">துறைமுகம் அந்த டோர் அதன் சாக்ச் ப்ராக்சியை வழங்குகிறது (இயல்புநிலை: முடக்க 9050 அல்லது 0)</string>
     <string name="pref_socks_dialog">சாக்ச் துறைமுகம் கட்டமைப்பு</string>
     <string name="pref_http_title">Tor http</string>
@@ -125,7 +124,6 @@
     <string name="ports_reachable_behind_a_restrictive_firewall">ஒரு கட்டுப்பாட்டு ஃபயர்வாலுக்கு பின்னால் துறைமுகங்கள் அடையக்கூடியவை</string>
     <string name="enter_ports">துறைமுகங்களை உள்ளிடவும்</string>
     <string name="hidden_service_request">ஒரு பயன்பாடு டோர் பிணையத்தில் துறைமுகம் %1$s இல் வெங்காய சேவையகத்தைத் திறக்க விரும்புகிறது. நீங்கள் பயன்பாட்டை நம்பினால் இது பாதுகாப்பானது.</string>
-    <string name="pref_disable_network_summary">இணையம் இல்லாதபோது டோர் தூங்க வைக்கவும்</string>
     <string name="newnym">நீங்கள் ஒரு புதிய டோர் அடையாளத்திற்கு மாறிவிட்டீர்கள்!</string>
     <string name="pref_open_proxy_on_all_interfaces_title">அனைத்து இடைமுகங்களிலும் பதிலாள் திறக்கவும்</string>
     <string name="pref_open_proxy_on_all_interfaces_summary">வைஃபை சகாக்கள், இணைக்கப்பட்ட சாதனங்கள் மற்றும் உங்கள் ஐபியுடன் இணைக்கக்கூடிய வேறு எவரையும் அனுமதிக்கவும், டோர் அணுகவும்</string>

--- a/app/src/main/res/values-th/strings.xml
+++ b/app/src/main/res/values-th/strings.xml
@@ -46,8 +46,6 @@
     <string name="third_party_software">ซอฟต์แวร์โดยผู้ผลิตอื่น:</string>
     <string name="hidden_service_request">โปรแกรมต้องการเปิดพอร์ต %1$d ที่ซ่อนอยู่ของเซิร์ฟเวอร์ให้เชื่อมกับเครือข่าย Tor การกระทำนี้ปลอดภัยถ้าคุณเชื่อถือโปรแกรมนั้น</string>
     <string name="set_locale_title">ภาษา</string>
-    <string name="pref_disable_network_title">ไม่พบเครือข่าย พักการใช้งานอัตโนมัติ</string>
-    <string name="pref_disable_network_summary">พักการใช้งาน Tor เมื่อไม่มีอินเทอร์เน็ต</string>
     <string name="newnym">คุณได้เปลี่ยนมาใช้ตัวตน Tor ใหม่แล้ว!</string>
     <string name="pref_socks_title">Tor SOCKS</string>
     <string name="pref_socks_summary">พอร์ตที่ Tor ให้บริการพร็อกซี SOCKS (ค่าเริ่มต้น: 9050 หรือ 0 ไปถึงไม่เปิดใช้งาน)</string>

--- a/app/src/main/res/values-tk/strings.xml
+++ b/app/src/main/res/values-tk/strings.xml
@@ -20,7 +20,6 @@
     <string name="pref_proxy_host_summary">Proksi Serweriň host ady</string>
     <string name="pref_proxy_password_title">Çykýan Proksi Paroly</string>
     <string name="license">Ygtyýarnama:</string>
-    <string name="pref_disable_network_summary">Internete giriş ýok wagty Tor-y uklat</string>
     <string name="newnym">Täze Tor şahsyýetine geçdiňiz!</string>
     <string name="pref_open_proxy_on_all_interfaces_title">Ähli Interfeýslerde Proksi Açyň</string>
     <string name="pref_http_title">Tor HTTP</string>
@@ -136,7 +135,6 @@
     <string name="fingerprints_nicks_countries_and_addresses_to_exclude">Gatnaşmajak barmak yzlary, gysgaltmalar, ýurtlar we salgylar</string>
     <string name="third_party_software">Üçünji tarap programma üpjünçiligi:</string>
     <string name="hidden_service_request">Bir programma, %1$s portdaky onion serwerini Tor network-ine açmak isleýär. Programma ynanýan bolsaňyz, bu howpsuz.</string>
-    <string name="pref_disable_network_title">Network ýok wagty Awto-Uky</string>
     <string name="pref_open_proxy_on_all_interfaces_summary">Wi-Fi ulgamlaryna, birikdirilen enjamlara we IP-ä birikdirip bilýänlere Tor-a girmäge rugsat beriň</string>
     <string name="pref_socks_title">Tor SOCKS</string>
     <string name="pref_socks_summary">Tor-uň SOCKS proksi hödürleýän porty (deslapky: 9050 ýa-da 0 ýapmak üçin)</string>

--- a/app/src/main/res/values-tl/strings.xml
+++ b/app/src/main/res/values-tl/strings.xml
@@ -43,8 +43,6 @@
     <string name="project_home">Project Home(s):</string>
     <string name="third_party_software">3rd-Party-Software:</string>
     <string name="set_locale_title">Wika</string>
-    <string name="pref_disable_network_title">Walang Auto-Sleep sa Network</string>
-    <string name="pref_disable_network_summary">Ilagay ang Tor sa sleep kapag walang internet na pwede</string>
     <string name="newnym">Ikaw ay nagpalit ng bagong pagkakakilanlan sa Tor!</string>
     <string name="save">I-save</string>
     <string name="name">Name</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -46,8 +46,6 @@
     <string name="third_party_software">Üçüncü Taraf Yazılım:</string>
     <string name="hidden_service_request">Bir uygulama %1$s numaralı bağlantı noktasındaki onion sunucusunu Tor ağına açmak istiyor. Uygulamaya güveniyorsanız bu güvenlidir.</string>
     <string name="set_locale_title">Dil</string>
-    <string name="pref_disable_network_title">Bağlantı Olmadığında Otomatik Uyku</string>
-    <string name="pref_disable_network_summary">İnternet bağlantısı olmadığında Tor uyku kipine geçsin</string>
     <string name="newnym">Yeni bir Tor kimliğine geçiş yaptınız!</string>
     <string name="pref_socks_title">Tor SOCKS</string>
     <string name="pref_socks_summary">Tor SOCKS vekil sunucusu için kullanılacak bağlantı noktası (öntanımlı değer: 9050, devre dışı bırakmak için 0)</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -46,8 +46,6 @@
     <string name="third_party_software">Програми сторонніх розробників: </string>
     <string name="hidden_service_request">Застосунок хоче відкрити сервер onion на порту %1$s до мережі Tor. Це безпечно, якщо ви довіряєте застосунку.</string>
     <string name="set_locale_title">Мова</string>
-    <string name="pref_disable_network_title">Переходити в режим сну без мережі</string>
-    <string name="pref_disable_network_summary">Переводити в режим сну за відсутності інтернет-з\'єднання</string>
     <string name="newnym">Ви перемкнулись на новий ідентифікатор Tor!</string>
     <string name="pref_socks_title">Tor SOCKS</string>
     <string name="pref_socks_summary">Порт, який Tor надає своєму SOCKS-проксі (усталено: 9050 або 0 для вимкнення)</string>

--- a/app/src/main/res/values-ur/strings.xml
+++ b/app/src/main/res/values-ur/strings.xml
@@ -64,8 +64,6 @@
     <string name="third_party_software">تیسری پارٹی سافٹ ویئر:</string>
     <string name="license">لائسنس:</string>
     <string name="hidden_service_request">ایک ایپ ٹور نیٹ ورک پر پورٹ %1$s پر اونین سرور کھولنا چاہتی ہے۔ اگر آپ ایپ پر بھروسہ کرتے ہیں تو یہ محفوظ ہے۔</string>
-    <string name="pref_disable_network_title">نیٹ ورک نہ ہونے پر خودکار سلیپ موڈ</string>
-    <string name="pref_disable_network_summary">جب انٹرنیٹ دستیاب نہ ہو تو ٹور کو سلیپ موڈ پر ڈال دیں</string>
     <string name="newnym">آپ نے ایک نئی ٹور شناخت اپنا لی ہے!</string>
     <string name="pref_open_proxy_on_all_interfaces_title">تمام انٹرفیسز پر پراکسی کھولیں</string>
     <string name="pref_open_proxy_on_all_interfaces_summary">وائی فائی کے ساتھیوں، ٹیتھرڈ ڈیوائسز اور کسی دوسرے کو جو آپ کے آئی پی سے منسلک ہو سکے، ٹور تک رسائی کی اجازت دیں</string>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -46,8 +46,6 @@
     <string name="project_home">Trang chủ dự án:</string>
     <string name="third_party_software">Phần mềm bên thứ 3:</string>
     <string name="set_locale_title">Ngôn ngữ</string>
-    <string name="pref_disable_network_title">Tự động \"ngủ\" khi không có mạng</string>
-    <string name="pref_disable_network_summary">Chuyển Tor sang chế độ ngủ nếu không có Internet</string>
     <string name="newnym">Bạn đã chuyển sang một danh tính Tor mới!</string>
     <string name="pref_socks_title">Cổng SOCKS</string>
     <string name="pref_socks_summary">Cổng để Tor đặt proxy SOCKS lên (mặc định: 9050 hoặc 0 để vô hiệu hóa)</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -44,8 +44,6 @@
     <string name="project_home">项目主页：</string>
     <string name="third_party_software">第三方软件：</string>
     <string name="set_locale_title">语言</string>
-    <string name="pref_disable_network_title">无网络时自动休眠</string>
-    <string name="pref_disable_network_summary">未连接到互联网时让 Tor 进入休眠状态</string>
     <string name="newnym">您已切换到新的 Tor 身份！</string>
     <string name="pref_socks_title">Tor SOCKS</string>
     <string name="pref_socks_summary">Tor 提供 SOCKS 代理的端口（默认值：9050，0 表示禁用）</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -46,8 +46,6 @@
     <string name="third_party_software">第三方軟體：</string>
     <string name="hidden_service_request">有一個應用程式想要在 Tor 網絡的連接埠 %1$s 上開啟 Onion 伺服器。如果你信任該應用程式，這是安全的。</string>
     <string name="set_locale_title">語言</string>
-    <string name="pref_disable_network_title">無網路時自動休眠</string>
-    <string name="pref_disable_network_summary">當沒有網路可用時，讓 Tor 休眠</string>
     <string name="newnym">您已切換到新的 Tor 身分！</string>
     <string name="pref_socks_title">Tor SOCKS 代理</string>
     <string name="pref_socks_summary">Tor 提供 SOCKS 代理的連接埠 (預設：9050，若設為 0 則關閉)</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -40,7 +40,7 @@
     <string name="fingerprints_nicks_countries_and_addresses_to_exclude">Fingerprints, nicks, countries and addresses to exclude</string>
     <string name="enter_exclude_nodes">Enter Exclude Nodes</string>
     <string name="strict_nodes">Strict Nodes</string>
-    <string name="strict_nodes_description">Treat Exclude Nodes settings as a requirement for building all circuits. This may break functionality if no circuits are able to be generated with your Exclude Nodes settings.</string>
+    <string name="strict_nodes_description">Treat Exclude Nodes settings as a requirement for building all circuits. This may break functionality if no circuits can be built with your Exclude Nodes settings.</string>
     <string name="reachable_addresses">Reachable Addresses</string>
     <string name="run_as_a_client_behind_a_firewall_with_restrictive_policies">Run as a client behind a firewall with restrictive policies</string>
     <string name="reachable_ports">Reachable ports</string>
@@ -59,8 +59,6 @@
     <string name="license">License:</string>
     <string name="hidden_service_request">An app wants to open onion server on port %1$s to the Tor network. This is safe if you trust the app.</string>
     <string name="set_locale_title">Language</string>
-    <string name="pref_disable_network_title">No Network Auto-Sleep</string>
-    <string name="pref_disable_network_summary">Put Tor to sleep when there is no internet available</string>
     <string name="newnym">You\'ve switched to a new Tor identity!</string>
     <string name="pref_open_proxy_on_all_interfaces_title">Open Proxy on All Interfaces</string>
     <string name="pref_open_proxy_on_all_interfaces_summary">Allow Wi-Fi peers, tethered devices and anyone else who can connect to your IP, to access Tor</string>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -338,14 +338,6 @@
             android:title="Debug Log"
             app:iconSpaceReserved="false" />
 
-        <CheckBoxPreference
-            android:defaultValue="true"
-            android:enabled="true"
-            android:key="pref_disable_network"
-            android:summary="@string/pref_disable_network_summary"
-            android:title="@string/pref_disable_network_title"
-            app:iconSpaceReserved="false" />
-
     </PreferenceScreen>
 
 </PreferenceScreen>


### PR DESCRIPTION
@n8fr8 what did this setting once do? Was trying to imagine how it modified the `torrc`. 

It seems like it's been removed for some time. So I just propose getting rid of the setting here all together. But I figure you have more context on what this once was, so maybe it'd be beneficial and trivial to it back too? 