### PR TITLE
Playstore release tweaks

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -40,9 +40,16 @@
     </queries>
 
     <!--
-    usesCleartextTraffic is needed for SSDP multicast local router discovery (which is an unencrypted
-    HTTP-style protocol) and for UPnP IGD requests to map ports for Snowflake Proxy, (which are also
-    unencrypted HTTP-style requests).
+        android:allowBackup="false"
+        "Note: For apps targeting Android 12 (API level 31) or higher, this behavior varies.
+        On devices from some device manufacturers, you can't disable device-to-device migration of
+        your app's files."
+        https://developer.android.com/about/versions/12/behavior-changes-12#backup-restore
+    -->
+    <!--
+        android:usesCleartextTraffic is needed for SSDP multicast local router discovery (which is
+        an unencrypted HTTP-style protocol) and for UPnP IGD requests to map ports for Snowflake
+        Proxy, (which are also unencrypted HTTP-style requests).
      -->
     <application
         android:name=".OrbotApp"
@@ -55,7 +62,6 @@
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
         android:supportsRtl="true"
-        android:taskAffinity=""
         android:theme="@style/DefaultTheme"
         android:usesCleartextTraffic="true">
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -40,16 +40,9 @@
     </queries>
 
     <!--
-        android:allowBackup="false"
-        "Note: For apps targeting Android 12 (API level 31) or higher, this behavior varies.
-        On devices from some device manufacturers, you can't disable device-to-device migration of
-        your app's files."
-        https://developer.android.com/about/versions/12/behavior-changes-12#backup-restore
-    -->
-    <!--
-        android:usesCleartextTraffic is needed for SSDP multicast local router discovery (which is
-        an unencrypted HTTP-style protocol) and for UPnP IGD requests to map ports for Snowflake
-        Proxy, (which are also unencrypted HTTP-style requests).
+    usesCleartextTraffic is needed for SSDP multicast local router discovery (which is an unencrypted
+    HTTP-style protocol) and for UPnP IGD requests to map ports for Snowflake Proxy, (which are also
+    unencrypted HTTP-style requests).
      -->
     <application
         android:name=".OrbotApp"

--- a/app/src/main/java/org/torproject/android/OrbotActivity.kt
+++ b/app/src/main/java/org/torproject/android/OrbotActivity.kt
@@ -68,7 +68,10 @@ class OrbotActivity : BaseActivity() {
 
         // programmatically set title to "Orbot" since camo mode will overwrite it here from manifest
         title = getString(R.string.app_name)
-
+        savedInstanceState?.let {
+            portSocks = it.getInt(BUNDLE_KEY_SOCKS, -1)
+            portHttp = it.getInt(BUNDLE_KEY_HTTP, -1)
+        }
         try {
             createOrbot()
 
@@ -77,6 +80,14 @@ class OrbotActivity : BaseActivity() {
             //clear malicious intent
             intent = null
             finish()
+        }
+    }
+
+    override fun onSaveInstanceState(outState: Bundle) {
+        super.onSaveInstanceState(outState)
+        outState.apply {
+            putInt(BUNDLE_KEY_SOCKS, portSocks)
+            putInt(BUNDLE_KEY_HTTP, portHttp)
         }
     }
 
@@ -324,7 +335,8 @@ class OrbotActivity : BaseActivity() {
 
     companion object {
         private const val TAG = "OrbotActivity"
-        private const val KEY_TOR_STATUS = "key_tor_status"
+        private const val BUNDLE_KEY_SOCKS = "socks"
+        private const val BUNDLE_KEY_HTTP = "http"
         const val REQUEST_CODE_VPN = 1234
 
         // Make sure this is only shown once per app-start, not on every device rotation.

--- a/app/src/main/java/org/torproject/android/util/Prefs.kt
+++ b/app/src/main/java/org/torproject/android/util/Prefs.kt
@@ -314,7 +314,7 @@ object Prefs {
         get() = cr?.getPrefBoolean(PREF_POWER_USER_MODE) ?: false
 
     var isSecureWindow: Boolean
-        get() = cr?.getPrefBoolean(PREF_SECURE_WINDOW_FLAG, true) ?: true
+        get() = cr?.getPrefBoolean(PREF_SECURE_WINDOW_FLAG) ?: false
         set(isFlagSecure) = cr?.putPref(PREF_SECURE_WINDOW_FLAG, isFlagSecure) ?: Unit
 
     const val DEFAULT_CAMO_DISABLED_ACTIVITY: String = "org.torproject.android.OrbotActivity"

--- a/app/src/main/res/values-fr-rFR/strings.xml
+++ b/app/src/main/res/values-fr-rFR/strings.xml
@@ -147,7 +147,7 @@
     <string name="asking">DEMANDER…</string>
     <string name="setting_padding">Rembourrage</string>
     <string name="setting_debug">Débogage</string>
-    <string name="menu_more">Plus d\'informations</string>
+    <string name="menu_more">Plus</string>
     <string name="option_only_when_charging">Uniquement en cas de charge</string>
     <string name="pref_isolate_port_summary">Utiliser un circuit différent pour chaque port de destination</string>
     <string name="pref_isolate_protocol_summary">Utiliser un circuit différent pour chaque protocole de connexion</string>

--- a/app/src/main/res/xml/data_extraction_rules.xml
+++ b/app/src/main/res/xml/data_extraction_rules.xml
@@ -26,10 +26,15 @@
         <exclude domain="root" path="file_to_exclude"/>
         -->
     </cloud-backup>
-    <!--
     <device-transfer>
-        <include .../>
-        <exclude .../>
-    </device-transfer>
+        <!--
+            ...
+    <include domain=["file" | "database" | "sharedpref" | "external" |
+                        "root"] path="string"/>
+    ...
+    <exclude domain=["file" | "database" | "sharedpref" | "external" |
+                        "root"] path="string"/>
+    ...
     -->
+    </device-transfer>
 </data-extraction-rules>

--- a/app/src/main/res/xml/data_extraction_rules.xml
+++ b/app/src/main/res/xml/data_extraction_rules.xml
@@ -26,15 +26,10 @@
         <exclude domain="root" path="file_to_exclude"/>
         -->
     </cloud-backup>
+    <!--
     <device-transfer>
-        <!--
-            ...
-    <include domain=["file" | "database" | "sharedpref" | "external" |
-                        "root"] path="string"/>
-    ...
-    <exclude domain=["file" | "database" | "sharedpref" | "external" |
-                        "root"] path="string"/>
-    ...
-    -->
+        <include .../>
+        <exclude .../>
     </device-transfer>
+    -->
 </data-extraction-rules>


### PR DESCRIPTION
Small changes/fixes made while trying to get around the play store rejection problem:

- Remove unused `android:hasFragileUserData="false"` from manifest. It defaults to false, so this does nothing. This let's us remove `"tools:suppressApi="29"` from the manifest too, giving us warnings when we do something on older APIs. If set to `true`, this prompts the user to backup their data on app uninstall 
- Remove `android:taskAffinity="'` from manifest. This causes legacy activities in the app (for hosting v3 onion services + v3 client authorization) to create duplicate Orbot's in the app switcher. Very longstanding bug. 
- In french, change "Plus d'information" on the bottom navigation menu to just "Plus". In English, this is the label at the bottom that reads "More". The text gets chopped off even on high resolution phones. "Plus" is legit French for this, and the french string is by far the longest out of _**all**_ the translations we have for this string. 

<img width="182" height="238" alt="image" src="https://github.com/user-attachments/assets/60bb3a50-6542-404c-9354-efb74db09318" />
<img width="256" height="93" alt="image" src="https://github.com/user-attachments/assets/3dddf45f-9e6d-4fce-af7c-1e862e706fa9" />
<img width="256" height="93" alt="image" src="https://github.com/user-attachments/assets/c017f3fd-969c-47d6-bf02-2c051e2614ad" />

- **Actually** fix defualt value for screen shot prevention for browser stack issues you were having. I had set the default to `false` in the prefs XML, but the actual Kotlin that retrieved the value still used `true` if the user had never set that preference. 