### PR TITLE
request ACCESS_LOCAL_NETWORK when enabling open proxy on all interfaces

### DIFF
--- a/app/src/main/java/org/torproject/android/service/tor/TorConfig.kt
+++ b/app/src/main/java/org/torproject/android/service/tor/TorConfig.kt
@@ -24,7 +24,13 @@ object TorConfig {
         val isolate = getIsolation()
         val ipv6Pref = getIpv6()
 
-        if (Prefs.openProxyOnAllInterfaces()) {
+        // on API 37+ this also needs ACCESS_LOCAL_NETWORK. If the pref is on but the permission
+        // got revoked (or was never granted), fall back to a localhost-only SOCKSPort instead of
+        // silently binding to an address nothing can reach.
+        val openOnAllInterfaces = Prefs.openProxyOnAllInterfaces() &&
+                NetworkUtils.needsAccessLocalNetworkPermission(context) != true
+
+        if (openOnAllInterfaces) {
             conf.add("SOCKSPort 0.0.0.0:$socksPortPref $ipv6Pref $isolate")
             conf.add("SocksPolicy accept *:*")
         } else {

--- a/app/src/main/java/org/torproject/android/service/tor/TorConfig.kt
+++ b/app/src/main/java/org/torproject/android/service/tor/TorConfig.kt
@@ -27,10 +27,7 @@ object TorConfig {
         // on API 37+ this also needs ACCESS_LOCAL_NETWORK. If the pref is on but the permission
         // got revoked (or was never granted), fall back to a localhost-only SOCKSPort instead of
         // silently binding to an address nothing can reach.
-        val openOnAllInterfaces = Prefs.openProxyOnAllInterfaces() &&
-                NetworkUtils.needsAccessLocalNetworkPermission(context) != true
-
-        if (openOnAllInterfaces) {
+        if (Prefs.openProxyOnAllInterfaces(context)) {
             conf.add("SOCKSPort 0.0.0.0:$socksPortPref $ipv6Pref $isolate")
             conf.add("SocksPolicy accept *:*")
         } else {
@@ -117,7 +114,6 @@ object TorConfig {
 
         val custom = Prefs.customTorRc
         if (!custom.isNullOrEmpty()) conf.add(custom)
-
         return conf.joinToString("\n")
     }
 

--- a/app/src/main/java/org/torproject/android/ui/kindness/SnowflakeProxyWrapper.kt
+++ b/app/src/main/java/org/torproject/android/ui/kindness/SnowflakeProxyWrapper.kt
@@ -12,6 +12,7 @@ import kotlinx.coroutines.launch
 import org.torproject.android.R
 import org.torproject.android.service.OrbotConstants
 import org.torproject.android.service.circumvention.BuiltInBridges
+import org.torproject.android.util.NetworkUtils
 import org.torproject.android.util.Prefs
 import org.torproject.android.util.showToast
 import java.io.BufferedReader
@@ -33,7 +34,7 @@ class SnowflakeProxyWrapper(private val service: SnowflakeProxyService) {
         if (proxy != null) return
         CoroutineScope(Dispatchers.IO).launch {
             val start = Random.nextInt(49152, 65536 - 2)
-            if (UPnPDialogFragment.needsAccessLocalNetworkPermission(service) != true) {
+            if (NetworkUtils.needsAccessLocalNetworkPermission(service) != true) {
                 for (port in (start..start + 2)) {
                     if (UPnP.openPortUDP(port, OrbotConstants.TAG)) {
                         mappedPorts.add(port)

--- a/app/src/main/java/org/torproject/android/ui/kindness/UPnPDialogFragment.kt
+++ b/app/src/main/java/org/torproject/android/ui/kindness/UPnPDialogFragment.kt
@@ -4,20 +4,16 @@ import android.Manifest
 import android.annotation.SuppressLint
 import android.app.AlertDialog
 import android.app.Dialog
-import android.content.Context
 import android.content.Intent
-import android.content.pm.PackageManager
 import android.net.Uri
-import android.os.Build
 import android.os.Bundle
 import android.provider.Settings
-import android.util.Log
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.core.app.ActivityCompat
-import androidx.core.content.ContextCompat
 import androidx.fragment.app.DialogFragment
 import androidx.fragment.app.FragmentManager
 import org.torproject.android.R
+import org.torproject.android.util.NetworkUtils
 import org.torproject.android.util.createWithCurves
 
 class UPnPDialogFragment : DialogFragment() {
@@ -34,7 +30,8 @@ class UPnPDialogFragment : DialogFragment() {
             .setMessage(msg)
 
         val accessLocalNetworkNeeded =
-            needsAccessLocalNetworkPermission(requireContext()) ?: return builder.createWithCurves()
+            NetworkUtils.needsAccessLocalNetworkPermission(requireContext())
+                ?: return builder.createWithCurves()
         if (accessLocalNetworkNeeded) {
             msg += "\n\n${getString(R.string.kindness_quality_upgrade_need_local_network)}"
             val repeatedlyDenied = ActivityCompat.shouldShowRequestPermissionRationale(
@@ -73,24 +70,6 @@ class UPnPDialogFragment : DialogFragment() {
 
         fun show(fragmentManager: FragmentManager) {
             UPnPDialogFragment().show(fragmentManager, TAG)
-        }
-
-        // returns null if permission Android 36 or lower, else true/false
-        fun needsAccessLocalNetworkPermission(context: Context): Boolean? {
-            if (Build.VERSION.SDK_INT < Build.VERSION_CODES.CINNAMON_BUN) {
-                return null
-            }
-            val checkAccessLocalNetworkPerm =
-                ContextCompat.checkSelfPermission(
-                    context,
-                    Manifest.permission.ACCESS_LOCAL_NETWORK
-                )
-            if (checkAccessLocalNetworkPerm == PackageManager.PERMISSION_DENIED) {
-                Log.d(TAG, "local network permission not granted for UPnP")
-                return true
-            }
-            Log.d(TAG, "Local network permission granted for UPnP")
-            return false
         }
     }
 }

--- a/app/src/main/java/org/torproject/android/ui/kindness/UPnPDialogFragment.kt
+++ b/app/src/main/java/org/torproject/android/ui/kindness/UPnPDialogFragment.kt
@@ -4,10 +4,7 @@ import android.Manifest
 import android.annotation.SuppressLint
 import android.app.AlertDialog
 import android.app.Dialog
-import android.content.Intent
-import android.net.Uri
 import android.os.Bundle
-import android.provider.Settings
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.core.app.ActivityCompat
 import androidx.fragment.app.DialogFragment
@@ -15,6 +12,7 @@ import androidx.fragment.app.FragmentManager
 import org.torproject.android.R
 import org.torproject.android.util.NetworkUtils
 import org.torproject.android.util.createWithCurves
+import org.torproject.android.util.openSystemSettings
 
 class UPnPDialogFragment : DialogFragment() {
     @SuppressLint("InlinedApi")
@@ -43,12 +41,7 @@ class UPnPDialogFragment : DialogFragment() {
             builder
                 .setNeutralButton(permissionButtonText) { _, _ ->
                     if (repeatedlyDenied) {
-                        activity?.startActivity(
-                            Intent(
-                                Settings.ACTION_APPLICATION_DETAILS_SETTINGS,
-                                Uri.fromParts("package", activity?.packageName, null)
-                            ).addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
-                        )
+                        openSystemSettings()
                     } else {
                         requestPermissionLauncher.launch(Manifest.permission.ACCESS_LOCAL_NETWORK)
                     }

--- a/app/src/main/java/org/torproject/android/ui/more/SettingsPreferenceFragment.kt
+++ b/app/src/main/java/org/torproject/android/ui/more/SettingsPreferenceFragment.kt
@@ -52,6 +52,13 @@ class SettingsPreferenceFragment : AbstractPreferenceFragment(), OnPreferenceCha
                 granted
         }
 
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.CINNAMON_BUN) {
+            Prefs.resetOpenProxyOnAllInterfacesIfPermissionRevoked(requireContext())
+        }
+    }
+
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         toolbar = view.findViewById(R.id.toolbar)
@@ -167,7 +174,7 @@ class SettingsPreferenceFragment : AbstractPreferenceFragment(), OnPreferenceCha
     @RequiresApi(Build.VERSION_CODES.CINNAMON_BUN)
     private fun requestLocalNetworkPermission() {
         AlertDialog.Builder(requireContext())
-            .setTitle(R.string.pref_open_proxy_on_all_interfaces_title )
+            .setTitle(R.string.pref_open_proxy_on_all_interfaces_title)
             .setMessage(R.string.open_proxy_needs_local_network_permission)
             .setPositiveButton(R.string.grant_permission) { _, _ ->
                 val repeatedlyDenied = ActivityCompat.shouldShowRequestPermissionRationale(

--- a/app/src/main/java/org/torproject/android/ui/more/SettingsPreferenceFragment.kt
+++ b/app/src/main/java/org/torproject/android/ui/more/SettingsPreferenceFragment.kt
@@ -173,7 +173,7 @@ class SettingsPreferenceFragment : AbstractPreferenceFragment(), OnPreferenceCha
 
     @RequiresApi(Build.VERSION_CODES.CINNAMON_BUN)
     private fun requestLocalNetworkPermission() {
-        AlertDialog.Builder(requireContext())
+        AlertDialog.Builder(requireContext(), R.style.OrbotDialogTheme)
             .setTitle(R.string.pref_open_proxy_on_all_interfaces_title)
             .setMessage(R.string.open_proxy_needs_local_network_permission)
             .setPositiveButton(R.string.grant_permission) { _, _ ->

--- a/app/src/main/java/org/torproject/android/ui/more/SettingsPreferenceFragment.kt
+++ b/app/src/main/java/org/torproject/android/ui/more/SettingsPreferenceFragment.kt
@@ -3,11 +3,8 @@ package org.torproject.android.ui.more
 
 import android.Manifest
 import android.app.AlertDialog
-import android.content.Intent
-import android.net.Uri
 import android.os.Build
 import android.os.Bundle
-import android.provider.Settings
 import android.text.InputType
 import android.view.View
 import androidx.activity.result.contract.ActivityResultContracts
@@ -30,6 +27,7 @@ import org.torproject.android.service.tor.ShadowSocks
 import org.torproject.android.util.NetworkUtils
 import org.torproject.android.util.Prefs
 import org.torproject.android.util.createWithCurves
+import org.torproject.android.util.openSystemSettings
 import org.torproject.android.util.removeEntry
 import org.torproject.android.util.sendIntentToService
 
@@ -177,12 +175,7 @@ class SettingsPreferenceFragment : AbstractPreferenceFragment(), OnPreferenceCha
                     Manifest.permission.ACCESS_LOCAL_NETWORK
                 )
                 if (repeatedlyDenied) {
-                    startActivity(
-                        Intent(
-                            Settings.ACTION_APPLICATION_DETAILS_SETTINGS,
-                            Uri.fromParts("package", requireActivity().packageName, null)
-                        ).addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
-                    )
+                    openSystemSettings()
                 } else {
                     requestLocalNetworkPermissionLauncher.launch(Manifest.permission.ACCESS_LOCAL_NETWORK)
                 }

--- a/app/src/main/java/org/torproject/android/ui/more/SettingsPreferenceFragment.kt
+++ b/app/src/main/java/org/torproject/android/ui/more/SettingsPreferenceFragment.kt
@@ -1,14 +1,21 @@
 /* Copyright (c) 2009, Nathan Freitas, Orbot / The Guardian Project - http://openideals.com/guardian */ /* See LICENSE for licensing information */
 package org.torproject.android.ui.more
 
+import android.Manifest
+import android.content.Intent
+import android.net.Uri
 import android.os.Build
 import android.os.Bundle
+import android.provider.Settings
 import android.text.InputType
 import android.view.View
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.app.AppCompatDelegate
 import androidx.appcompat.widget.Toolbar
+import androidx.core.app.ActivityCompat
 import androidx.core.os.LocaleListCompat
+import androidx.preference.CheckBoxPreference
 import androidx.preference.EditTextPreference
 import androidx.preference.ListPreference
 import androidx.preference.Preference
@@ -18,9 +25,11 @@ import org.torproject.android.R
 import org.torproject.android.localization.Languages
 import org.torproject.android.service.OrbotConstants
 import org.torproject.android.service.tor.ShadowSocks
+import org.torproject.android.util.NetworkUtils
 import org.torproject.android.util.Prefs
 import org.torproject.android.util.removeEntry
 import org.torproject.android.util.sendIntentToService
+import org.torproject.android.util.showToast
 
 class SettingsPreferenceFragment : AbstractPreferenceFragment(), OnPreferenceChangeListener {
     private var toolbar: Toolbar? = null
@@ -36,6 +45,12 @@ class SettingsPreferenceFragment : AbstractPreferenceFragment(), OnPreferenceCha
     val passwordPrefs = listOf(
         "pref_proxy_password"
     )
+
+    private val requestLocalNetworkPermissionLauncher =
+        registerForActivityResult(ActivityResultContracts.RequestPermission()) { granted ->
+            findPreference<CheckBoxPreference>("pref_open_proxy_on_all_interfaces")?.isChecked =
+                granted
+        }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
@@ -108,6 +123,18 @@ class SettingsPreferenceFragment : AbstractPreferenceFragment(), OnPreferenceCha
                 true
             }
 
+        findPreference<CheckBoxPreference>("pref_open_proxy_on_all_interfaces")?.onPreferenceChangeListener =
+            OnPreferenceChangeListener { _, newValue ->
+                if (newValue == true && NetworkUtils.needsAccessLocalNetworkPermission(requireContext()) == true) {
+                    requestLocalNetworkPermission()
+                    // don't let the CheckBoxPreference commit yet, it gets set once the
+                    // permission result comes back
+                    false
+                } else {
+                    true
+                }
+            }
+
         val proxyType = findPreference<ListPreference>("pref_proxy_type")
         if (!ShadowSocks.isShadowSocksSupported()) {
             proxyType?.removeEntry(ShadowSocks.SCHEME)
@@ -121,6 +148,24 @@ class SettingsPreferenceFragment : AbstractPreferenceFragment(), OnPreferenceCha
             proxyType.onPreferenceChangeListener = this
 
             onPreferenceChange(proxyType, proxyType.value)
+        }
+    }
+
+    private fun requestLocalNetworkPermission() {
+        requireContext().showToast(R.string.open_proxy_needs_local_network_permission)
+        val repeatedlyDenied = ActivityCompat.shouldShowRequestPermissionRationale(
+            requireActivity(),
+            Manifest.permission.ACCESS_LOCAL_NETWORK
+        )
+        if (repeatedlyDenied) {
+            startActivity(
+                Intent(
+                    Settings.ACTION_APPLICATION_DETAILS_SETTINGS,
+                    Uri.fromParts("package", requireActivity().packageName, null)
+                ).addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+            )
+        } else {
+            requestLocalNetworkPermissionLauncher.launch(Manifest.permission.ACCESS_LOCAL_NETWORK)
         }
     }
 

--- a/app/src/main/java/org/torproject/android/ui/more/SettingsPreferenceFragment.kt
+++ b/app/src/main/java/org/torproject/android/ui/more/SettingsPreferenceFragment.kt
@@ -10,6 +10,7 @@ import android.provider.Settings
 import android.text.InputType
 import android.view.View
 import androidx.activity.result.contract.ActivityResultContracts
+import androidx.annotation.RequiresApi
 import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.app.AppCompatDelegate
 import androidx.appcompat.widget.Toolbar
@@ -48,7 +49,7 @@ class SettingsPreferenceFragment : AbstractPreferenceFragment(), OnPreferenceCha
 
     private val requestLocalNetworkPermissionLauncher =
         registerForActivityResult(ActivityResultContracts.RequestPermission()) { granted ->
-            findPreference<CheckBoxPreference>("pref_open_proxy_on_all_interfaces")?.isChecked =
+            findPreference<CheckBoxPreference>(Prefs.PREF_OPEN_PROXY_ON_ALL_INTERFACES)?.isChecked =
                 granted
         }
 
@@ -123,17 +124,10 @@ class SettingsPreferenceFragment : AbstractPreferenceFragment(), OnPreferenceCha
                 true
             }
 
-        findPreference<CheckBoxPreference>("pref_open_proxy_on_all_interfaces")?.onPreferenceChangeListener =
-            OnPreferenceChangeListener { _, newValue ->
-                if (newValue == true && NetworkUtils.needsAccessLocalNetworkPermission(requireContext()) == true) {
-                    requestLocalNetworkPermission()
-                    // don't let the CheckBoxPreference commit yet, it gets set once the
-                    // permission result comes back
-                    false
-                } else {
-                    true
-                }
-            }
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.CINNAMON_BUN) {
+            setListenersForLocalNetworkPreferences()
+        }
+
 
         val proxyType = findPreference<ListPreference>("pref_proxy_type")
         if (!ShadowSocks.isShadowSocksSupported()) {
@@ -151,6 +145,27 @@ class SettingsPreferenceFragment : AbstractPreferenceFragment(), OnPreferenceCha
         }
     }
 
+
+    @RequiresApi(Build.VERSION_CODES.CINNAMON_BUN)
+    private fun setListenersForLocalNetworkPreferences() {
+        findPreference<CheckBoxPreference>(Prefs.PREF_OPEN_PROXY_ON_ALL_INTERFACES)?.onPreferenceChangeListener =
+            OnPreferenceChangeListener { _, newValue ->
+                if (newValue == true && NetworkUtils.needsAccessLocalNetworkPermission(
+                        requireContext()
+                    ) == true
+                ) {
+                    requestLocalNetworkPermission()
+                    // don't let the CheckBoxPreference commit yet, it gets set once the
+                    // permission result comes back
+                    false
+                } else {
+                    true
+                }
+            }
+
+    }
+
+    @RequiresApi(Build.VERSION_CODES.CINNAMON_BUN)
     private fun requestLocalNetworkPermission() {
         requireContext().showToast(R.string.open_proxy_needs_local_network_permission)
         val repeatedlyDenied = ActivityCompat.shouldShowRequestPermissionRationale(

--- a/app/src/main/java/org/torproject/android/ui/more/SettingsPreferenceFragment.kt
+++ b/app/src/main/java/org/torproject/android/ui/more/SettingsPreferenceFragment.kt
@@ -2,6 +2,7 @@
 package org.torproject.android.ui.more
 
 import android.Manifest
+import android.app.AlertDialog
 import android.content.Intent
 import android.net.Uri
 import android.os.Build
@@ -28,9 +29,9 @@ import org.torproject.android.service.OrbotConstants
 import org.torproject.android.service.tor.ShadowSocks
 import org.torproject.android.util.NetworkUtils
 import org.torproject.android.util.Prefs
+import org.torproject.android.util.createWithCurves
 import org.torproject.android.util.removeEntry
 import org.torproject.android.util.sendIntentToService
-import org.torproject.android.util.showToast
 
 class SettingsPreferenceFragment : AbstractPreferenceFragment(), OnPreferenceChangeListener {
     private var toolbar: Toolbar? = null
@@ -167,21 +168,28 @@ class SettingsPreferenceFragment : AbstractPreferenceFragment(), OnPreferenceCha
 
     @RequiresApi(Build.VERSION_CODES.CINNAMON_BUN)
     private fun requestLocalNetworkPermission() {
-        requireContext().showToast(R.string.open_proxy_needs_local_network_permission)
-        val repeatedlyDenied = ActivityCompat.shouldShowRequestPermissionRationale(
-            requireActivity(),
-            Manifest.permission.ACCESS_LOCAL_NETWORK
-        )
-        if (repeatedlyDenied) {
-            startActivity(
-                Intent(
-                    Settings.ACTION_APPLICATION_DETAILS_SETTINGS,
-                    Uri.fromParts("package", requireActivity().packageName, null)
-                ).addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
-            )
-        } else {
-            requestLocalNetworkPermissionLauncher.launch(Manifest.permission.ACCESS_LOCAL_NETWORK)
-        }
+        AlertDialog.Builder(requireContext())
+            .setTitle(R.string.pref_open_proxy_on_all_interfaces_title )
+            .setMessage(R.string.open_proxy_needs_local_network_permission)
+            .setPositiveButton(R.string.grant_permission) { _, _ ->
+                val repeatedlyDenied = ActivityCompat.shouldShowRequestPermissionRationale(
+                    requireActivity(),
+                    Manifest.permission.ACCESS_LOCAL_NETWORK
+                )
+                if (repeatedlyDenied) {
+                    startActivity(
+                        Intent(
+                            Settings.ACTION_APPLICATION_DETAILS_SETTINGS,
+                            Uri.fromParts("package", requireActivity().packageName, null)
+                        ).addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+                    )
+                } else {
+                    requestLocalNetworkPermissionLauncher.launch(Manifest.permission.ACCESS_LOCAL_NETWORK)
+                }
+            }
+            .setNegativeButton(android.R.string.cancel, null)
+            .createWithCurves()
+            .show()
     }
 
     override fun onPreferenceChange(preference: Preference, newValue: Any?): Boolean {

--- a/app/src/main/java/org/torproject/android/util/NetworkUtils.kt
+++ b/app/src/main/java/org/torproject/android/util/NetworkUtils.kt
@@ -1,10 +1,14 @@
 package org.torproject.android.util
 
+import android.Manifest
 import android.content.Context
+import android.content.pm.PackageManager
 import android.net.ConnectivityManager
 import android.net.NetworkCapabilities
 import android.net.VpnService
+import android.os.Build
 import android.util.Log
+import androidx.core.content.ContextCompat
 import java.net.InetSocketAddress
 import java.net.Socket
 
@@ -76,5 +80,28 @@ object NetworkUtils {
         } catch (_: Exception) {
             return false
         }
+    }
+
+    /**
+     * Checks whether ACCESS_LOCAL_NETWORK still needs to be requested from the user. Any feature
+     * that talks to devices on the LAN (kindness mode's UPnP probing, or the SOCKS/HTTP proxy
+     * listening on all interfaces) needs this permission on Android 17+.
+     *
+     * Returns null on Android 16 and below, where the permission doesn't exist.
+     */
+    fun needsAccessLocalNetworkPermission(context: Context): Boolean? {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.CINNAMON_BUN) {
+            return null
+        }
+        val checkAccessLocalNetworkPerm = ContextCompat.checkSelfPermission(
+            context,
+            Manifest.permission.ACCESS_LOCAL_NETWORK
+        )
+        if (checkAccessLocalNetworkPerm == PackageManager.PERMISSION_DENIED) {
+            Log.d(TAG, "local network permission not granted")
+            return true
+        }
+        Log.d(TAG, "local network permission granted")
+        return false
     }
 }

--- a/app/src/main/java/org/torproject/android/util/OrbotExtensionFunctions.kt
+++ b/app/src/main/java/org/torproject/android/util/OrbotExtensionFunctions.kt
@@ -5,6 +5,7 @@ import android.app.AlarmManager
 import android.app.AlertDialog
 import android.content.Context
 import android.content.Intent
+import android.net.Uri
 import android.net.VpnService
 import android.os.Build
 import android.os.PowerManager
@@ -135,6 +136,16 @@ fun Fragment.haveIBeenDetached(): Boolean {
     if (retVal)
         Log.d(javaClass.simpleName, "has been detached on (other) Thread, aborting...")
     return retVal
+}
+
+// open top-level system settings for Orbot
+fun Fragment.openSystemSettings() {
+    activity?.startActivity(
+        Intent(
+            Settings.ACTION_APPLICATION_DETAILS_SETTINGS,
+            Uri.fromParts("package", activity?.packageName, null)
+        ).addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+    )
 }
 
 fun ListPreference.removeEntry(label: String) {

--- a/app/src/main/java/org/torproject/android/util/Prefs.kt
+++ b/app/src/main/java/org/torproject/android/util/Prefs.kt
@@ -22,7 +22,7 @@ object Prefs {
     private const val PREF_ENABLE_LOGGING = "pref_enable_logging"
     private const val PREF_START_ON_BOOT = "pref_start_boot"
     private const val PREF_ALLOW_BACKGROUND_STARTS = "pref_allow_background_starts"
-    private const val PREF_OPEN_PROXY_ON_ALL_INTERFACES = "pref_open_proxy_on_all_interfaces"
+    const val PREF_OPEN_PROXY_ON_ALL_INTERFACES = "pref_open_proxy_on_all_interfaces"
     private const val PREF_USE_VPN = "pref_vpn"
     private const val PREF_LAST_SNOWFLAKE_QUALITY_CHECK = "pref_last_snowflake_quality_check"
     private const val PREF_EXIT_NODES = "pref_exit_nodes"

--- a/app/src/main/java/org/torproject/android/util/Prefs.kt
+++ b/app/src/main/java/org/torproject/android/util/Prefs.kt
@@ -2,6 +2,7 @@ package org.torproject.android.util
 
 import android.content.ContentResolver
 import android.content.Context
+import android.os.Build
 import androidx.work.ExistingPeriodicWorkPolicy
 import androidx.work.PeriodicWorkRequest
 import androidx.work.WorkManager
@@ -57,7 +58,6 @@ object Prefs {
     const val PREF_ORBOT_SERVICE_LOG = "pref_orbotservice_log"
 
     private var cr: ContentResolver? = null
-
 
     var currentVersionForUpdate: Int
         get() = cr?.getPrefInt(PREF_CURRENT_VERSION) ?: 0
@@ -159,8 +159,13 @@ object Prefs {
         return cr?.getPrefBoolean(PREF_ALLOW_BACKGROUND_STARTS, true) ?: true
     }
 
-    fun openProxyOnAllInterfaces(): Boolean {
-        return cr?.getPrefBoolean(PREF_OPEN_PROXY_ON_ALL_INTERFACES) ?: false
+    fun openProxyOnAllInterfaces(context: Context): Boolean {
+        val prefSet =  cr?.getPrefBoolean(PREF_OPEN_PROXY_ON_ALL_INTERFACES) ?: false
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.CINNAMON_BUN) {
+            // on API 37+ this also needs the ACCESS_LOCAL_NETWORK permission
+            return prefSet && NetworkUtils.needsAccessLocalNetworkPermission(context) != true
+        }
+        return prefSet
     }
 
     @JvmStatic

--- a/app/src/main/java/org/torproject/android/util/Prefs.kt
+++ b/app/src/main/java/org/torproject/android/util/Prefs.kt
@@ -3,6 +3,7 @@ package org.torproject.android.util
 import android.content.ContentResolver
 import android.content.Context
 import android.os.Build
+import androidx.annotation.RequiresApi
 import androidx.work.ExistingPeriodicWorkPolicy
 import androidx.work.PeriodicWorkRequest
 import androidx.work.WorkManager
@@ -166,6 +167,17 @@ object Prefs {
             return prefSet && NetworkUtils.needsAccessLocalNetworkPermission(context) != true
         }
         return prefSet
+    }
+
+    @RequiresApi(Build.VERSION_CODES.CINNAMON_BUN)
+    fun resetOpenProxyOnAllInterfacesIfPermissionRevoked(context: Context) {
+        // if the preference was set
+        if (cr?.getPrefBoolean(PREF_OPEN_PROXY_ON_ALL_INTERFACES) ?: false) {
+            // but the permission was revoked by the user outside Orbot
+            if (NetworkUtils.needsAccessLocalNetworkPermission(context) == true) {
+                cr?.putPref(PREF_OPEN_PROXY_ON_ALL_INTERFACES, false)
+            }
+        }
     }
 
     @JvmStatic

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -62,6 +62,7 @@
     <string name="newnym">You\'ve switched to a new Tor identity!</string>
     <string name="pref_open_proxy_on_all_interfaces_title">Open Proxy on All Interfaces</string>
     <string name="pref_open_proxy_on_all_interfaces_summary">Allow Wi-Fi peers, tethered devices and anyone else who can connect to your IP, to access Tor</string>
+    <string name="open_proxy_needs_local_network_permission">On Android 17 and higher, Orbot needs the Allow Access to Nearby Devices permission to open the proxy on all interfaces.</string>
     <string name="pref_socks_title">Tor SOCKS</string>
     <string name="pref_socks_summary">Port that Tor offers its SOCKS proxy on (default: 9050 or 0 to disable)</string>
     <string name="pref_socks_dialog">SOCKS Port Config</string>


### PR DESCRIPTION
Fixes #1743

The "Open Proxy on All Interfaces" setting makes Tor bind its SOCKS port to `0.0.0.0` (`TorConfig.kt`), which on Android 17 needs the `ACCESS_LOCAL_NETWORK` permission. Right now we only ever request that permission from the kindness mode UPnP dialog, so flipping this setting on an API 37 device just produces a proxy that nothing on the LAN can actually reach - no prompt, no error, it just doesn't work.

What this does:

- Moved `needsAccessLocalNetworkPermission()` out of `UPnPDialogFragment` and into `NetworkUtils`, so it's shared instead of duplicated. `UPnPDialogFragment` and `SnowflakeProxyWrapper` now call the shared version.
- `SettingsPreferenceFragment` now hooks the "Open Proxy on All Interfaces" checkbox: turning it on triggers a permission request first (same grant / deny / "permanently denied -> app settings" flow the kindness dialog already uses), and the checkbox only gets checked once the permission is actually granted.
- `TorConfig.build()` falls back to a localhost-only `SOCKSPort` if the preference is on but the permission isn't (e.g. revoked after the fact in system settings), so we never emit a `0.0.0.0` config nothing can reach.
- One new string for the permission rationale toast.

Verified by reading through the existing kindness-mode permission flow and mirroring it exactly, and by checking every call site of the old `UPnPDialogFragment.needsAccessLocalNetworkPermission` (there were two: the dialog itself and `SnowflakeProxyWrapper`) to make sure both got updated. I don't have a Java/Gradle toolchain in this environment so I couldn't build or run this - I'd appreciate someone testing the actual permission dialog on an API 37 emulator/device before merge. I also haven't tested the LAN end-to-end (a second device actually connecting through the opened proxy), just that the config and permission flow line up.
