### PR TITLE
Add select-all option in app manager

### DIFF
--- a/app/src/main/java/org/torproject/android/ui/AppManagerFragment.kt
+++ b/app/src/main/java/org/torproject/android/ui/AppManagerFragment.kt
@@ -101,6 +101,16 @@ class AppManagerFragment : Fragment(), View.OnClickListener {
             override fun afterTextChanged(s: Editable?) {}
         })
 
+        binding.selectAllCheck.setOnCheckedChangeListener { _, isChecked ->
+            for (item in filteredList) {
+                item.app?.isTorified = isChecked
+            }
+            (adapterAppsAll as? ArrayAdapter<*>)?.notifyDataSetChanged()
+        }
+        binding.selectAllLayout.setOnClickListener { _ ->
+            binding.selectAllCheck.isChecked = !binding.selectAllCheck.isChecked
+        }
+
         alSuggested = OrbotConstants.VPN_SUGGESTED_APPS
 
         with(binding.toolbar) {

--- a/app/src/main/res/layout/fragment_app_manager.xml
+++ b/app/src/main/res/layout/fragment_app_manager.xml
@@ -64,12 +64,51 @@
             android:visibility="gone"
             tools:visibility="visible" />
 
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:id="@+id/selectAllLayout"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="@dimen/activity_horizontal_margin"
+            android:layout_marginTop="64dp"
+            android:layout_marginEnd="@dimen/activity_horizontal_margin"
+            android:layout_marginBottom="8dp"
+            android:clickable="true"
+            android:focusable="true"
+            android:background="?attr/selectableItemBackground"
+            android:visibility="visible">
+
+            <com.google.android.material.checkbox.MaterialCheckBox
+                android:id="@+id/selectAllCheck"
+                android:layout_width="wrap_content"
+                android:layout_height="match_parent"
+                android:layout_marginEnd="@dimen/activity_horizontal_margin"
+                app:buttonTint="@color/menu_header"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent" />
+
+            <TextView
+                android:id="@+id/selectAllText"
+                android:visibility="visible"
+                android:layout_marginStart="8dp"
+                android:textColor="@color/text_purple"
+                android:layout_width="wrap_content"
+                android:textStyle="bold"
+                android:layout_height="wrap_content"
+                android:clickable="false"
+                android:focusable="false"
+                android:text="@string/apps_select_all"
+                app:layout_constraintStart_toEndOf="@id/selectAllCheck"
+                app:layout_constraintTop_toTopOf="parent"
+                app:layout_constraintBottom_toBottomOf="parent" />
+
+        </androidx.constraintlayout.widget.ConstraintLayout>
+
         <GridView
             android:id="@+id/applistview"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
             android:layout_marginStart="@dimen/activity_horizontal_margin"
-            android:layout_marginTop="64dp"
+            android:layout_marginTop="100dp"
             android:layout_marginEnd="@dimen/activity_horizontal_margin"
             android:layout_marginBottom="4dp"
             android:gravity="center"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -185,6 +185,7 @@
     <string name="Enabled">Enabled</string>
     <string name="Disabled">Disabled</string>
     <string name="Paused">Paused</string>
+    <string name="apps_select_all">Select All</string>
     <string name="app_suggested_subtitle">Orbot works best with messaging and social media apps.</string>
     <string name="apps_suggested_title">Suggested Apps</string>
     <string name="apps_other_apps">Other Apps</string>


### PR DESCRIPTION
Closes #1714

This PR adds a "Select All" checkbox in the App Manager menu that can be used to select/deselect all the apps part of the search query at once. Note: I don't know much Kotlin, but this issue looked pretty straightforward, so I thought I could give it a try. Please feel free to close it!

Instead of selecting all the apps as suggested in the issue, we select based on the current search query. Here is a preview (tested in LineageOS emulated using Waydroid; I will test on GrapheneOS on Pixel 10 when I get a chance):

https://github.com/user-attachments/assets/77177f95-ea31-4974-b7ec-d1152cd9fac9

I am not sure how we should handle the checkbox state when the query is changed, however. Right now, it just retains its state, and this makes sense to me. But please let me know if you would prefer a different approach!

Thanks everyone involved in building Orbot!

_LLM Disclosure: I have used LLM tools only for reviewing my work. No code/comment/text in this PR has been generated by an LLM._