### PR TITLE
fix Bridge.doh getter reading the dot parameter

### DIFF
--- a/app/src/main/java/org/torproject/android/service/circumvention/Bridge.kt
+++ b/app/src/main/java/org/torproject/android/service/circumvention/Bridge.kt
@@ -188,7 +188,7 @@ class Bridge(var raw: String) {
         get() = getPiece("udp")
 
     val doh
-        get() = getPiece("dot")
+        get() = getPiece("doh")
 
     val dot
         get() = getPiece("dot")


### PR DESCRIPTION
`Bridge.doh` calls `getPiece("dot")`. Copy paste slip from the `dot` getter below it, shipped in #1629. A `doh=` line parses to null and a Builder round trip drops the resolver. A `dot=` line leaks its value into `doh` and the rebuilt line grows a bogus duplicate.

No Android toolchain here so I compiled the untouched `Bridge.kt` with kotlinc 2.4.10 plus kotlinx-serialization-core 1.11.0 and fed it the first `BuiltInBridges.dnsttBridges` line. On master:

```
doh line -> bridge.doh = null
doh line round trip    = dnstt 192.0.2.4:1 A998F319ADB60EE344540EC4B21524CC484F96BE pubkey=241169008830694749fe96bb070c4855c5bb5b9c47b3833ed7d88521ba30a43f domain=t.ruhnama.net
dot line -> bridge.doh = dns.google:853
dot line round trip    = dnstt 192.0.2.4:1 A998F319ADB60EE344540EC4B21524CC484F96BE doh=dns.google:853 dot=dns.google:853 pubkey=241169008830694749fe96bb070c4855c5bb5b9c47b3833ed7d88521ba30a43f domain=t.ruhnama.net
```

With the patch:

```
doh line -> bridge.doh = https://dns.google/dns-query
doh line round trip    = dnstt 192.0.2.4:1 A998F319ADB60EE344540EC4B21524CC484F96BE doh=https://dns.google/dns-query pubkey=241169008830694749fe96bb070c4855c5bb5b9c47b3833ed7d88521ba30a43f domain=t.ruhnama.net
dot line -> bridge.doh = null
dot line round trip    = dnstt 192.0.2.4:1 A998F319ADB60EE344540EC4B21524CC484F96BE dot=dns.google:853 pubkey=241169008830694749fe96bb070c4855c5bb5b9c47b3833ed7d88521ba30a43f domain=t.ruhnama.net
```

Both lines now round trip byte for byte. To be fair nothing hits this today because `getUdpDnstt()` nulls both params before rebuilding. It only bites the next consumer of `Bridge.doh`. Want a follow up that adds a small parser test around these getters?
