### PR TITLE
Fix Bridge parsing for transport lines with no fingerprint

### DIFF
--- a/app/src/main/java/org/torproject/android/service/circumvention/Bridge.kt
+++ b/app/src/main/java/org/torproject/android/service/circumvention/Bridge.kt
@@ -111,12 +111,18 @@ class Bridge(var raw: String) {
         get() {
             val pieces = raw.split(" ").toMutableList()
 
-            // "Vanilla" bridges (conventional relays without obfuscation) don't have a transport.
-            // Add an empty one, so parsing works.
-            if (pieces.size < 3) {
-                pieces.add(0, "")
+            // "Vanilla" bridges (conventional relays without obfuscation) don't have a transport,
+            // so their first piece is already the address, not a transport name. Telling them
+            // apart by piece count alone breaks on a transport bridge line that is missing its
+            // (optional) fingerprint, e.g. "obfs4 192.0.2.5:443", which also only has 2 pieces.
+            // Check what the first piece actually looks like instead: transport names are plain
+            // words, while addresses always contain a dot (IPv4) or start with "[" (IPv6).
+            val firstLooksLikeAddress = pieces.firstOrNull()?.let {
+                it.contains(".") || it.startsWith("[")
+            } ?: false
 
-                return pieces
+            if (firstLooksLikeAddress) {
+                pieces.add(0, "")
             }
 
             return pieces


### PR DESCRIPTION
I found a parsing bug in `Bridge.kt` while reading the bridge-line handling.

`Bridge.rawPieces` decides whether a raw line has a transport prefix (like `obfs4` or `dnstt`) purely by counting space-separated pieces. Fewer than 3 pieces, and it assumes a vanilla bridge with no transport and shifts everything over by inserting an empty transport slot.

That breaks for a transport line that leaves out the optional relay fingerprint, for example:

    obfs4 192.0.2.5:443

That is 2 pieces, so the code treats it as vanilla: `transport` comes back null and `address` comes back as the literal `"obfs4"` instead of `192.0.2.5:443`. The fingerprint is optional in both Tor's own bridge-line syntax and this app's own `CustomBridgeBottomSheet` regex, so this is a line someone could plausibly paste into the custom bridge screen.

The fix checks what the first piece looks like instead of counting: a transport name is a plain word, while an address has a dot (IPv4) or starts with `[` (IPv6). I swapped the piece-count check for that.

I verified this by pulling the exact getter bodies out of `Bridge.kt` into a standalone Kotlin file and running them (no Android, no Gradle): the line above parses correctly after the fix, and every bridge format bundled in the app's assets (obfs4, meek, dnstt, vanilla IPv4 and IPv6) still parses exactly as before. I don't have the Android SDK here, so I could not run the app itself. Let me know if there is something about real-world bridge lines I am missing.
