### PR TITLE
normalize unicode spaces in custom bridge input

### DIFF
--- a/app/src/main/java/org/torproject/android/ui/connect/CustomBridgeBottomSheet.kt
+++ b/app/src/main/java/org/torproject/android/ui/connect/CustomBridgeBottomSheet.kt
@@ -38,12 +38,23 @@ class CustomBridgeBottomSheet : OrbotBottomSheetDialogFragment() {
                     + """[ \t\f\w\-/+:=.,\[\]]*$""" // Optional bridge arguments (different per bridge type, subject to change)
         )
 
+        // HTML email (e.g. the Tor Project's bridge distribution templates) can substitute a
+        // non-breaking space or another Unicode space variant for a regular space when a bridge
+        // line is copied out. \s in validBridgeRegex above only matches ASCII whitespace, and
+        // Bridge.kt splits on a literal " ", so those bridges get rejected or parsed wrong.
+        private val unicodeSpaceRegex = Regex("\\p{Zs}")
+
+        // One cleaning path for validation and saving: normalize any Unicode space to a regular
+        // space, split into lines (which also handles \r\n from desktop pastes) and drop blanks,
+        // so exactly the lines that were validated are the lines that get stored.
+        fun cleanBridgeLines(input: String): List<String> {
+            return input.replace(unicodeSpaceRegex, " ").lines().filter { it.isNotBlank() }
+        }
+
         fun isValidBridge(input: String): Boolean {
-            return input.lines()
-                .filter { it.isNotEmpty() && it.isNotBlank() }
-                .all {
-                    it.matches(validBridgeRegex)
-                }
+            return cleanBridgeLines(input).all {
+                it.matches(validBridgeRegex)
+            }
         }
     }
 
@@ -113,7 +124,9 @@ class CustomBridgeBottomSheet : OrbotBottomSheetDialogFragment() {
         binding.btnAction.setOnClickListener {
             Prefs.transport = Transport.CUSTOM
             Prefs.smartConnect = false
-            Prefs.bridgesList = binding.etBridges.text?.split("\n") ?: emptyList()
+            Prefs.bridgesList = binding.etBridges.text?.let {
+                cleanBridgeLines(it.toString())
+            } ?: emptyList()
             dismiss()
             val parent = requireActivity().supportFragmentManager.findFragmentByTag(
                 ConfigConnectionBottomSheet.TAG

--- a/app/src/test/java/org/torproject/android/ui/connect/CustomBridgeBottomSheetTest.kt
+++ b/app/src/test/java/org/torproject/android/ui/connect/CustomBridgeBottomSheetTest.kt
@@ -1,0 +1,74 @@
+package org.torproject.android.ui.connect
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class CustomBridgeBottomSheetTest {
+
+    // U+00A0 NO-BREAK SPACE, the character HTML email substitutes for a regular space.
+    private val nbsp = "\u00A0"
+
+    @Test
+    fun nbspContaminatedObfs4BridgeIsValid() {
+        val line = "obfs4${nbsp}192.0.2.5:443${nbsp}D9A82D2F9C2F65A18407B1D2B764F130847F8B5D" +
+                "${nbsp}cert=bjRaMrr1BRiAW8IE9U5z27fQaYgOhX1UCmOpg2pFpoMvo6ZgQMzLsaTzzQNTlm7hNcb+Sg"
+
+        assertTrue(CustomBridgeBottomSheet.isValidBridge(line))
+    }
+
+    @Test
+    fun nbspContaminatedVanillaBridgeIsValid() {
+        val line = "192.0.2.5:443${nbsp}D9A82D2F9C2F65A18407B1D2B764F130847F8B5D"
+
+        assertTrue(CustomBridgeBottomSheet.isValidBridge(line))
+    }
+
+    @Test
+    fun plainAsciiSpaceBridgesStillValidate() {
+        val obfs4 = "obfs4 37.218.245.14:38224 D9A82D2F9C2F65A18407B1D2B764F130847F8B5D " +
+                "cert=bjRaMrr1BRiAW8IE9U5z27fQaYgOhX1UCmOpg2pFpoMvo6ZgQMzLsaTzzQNTlm7hNcb+Sg iat-mode=0"
+        val vanilla = "192.0.2.5:443 D9A82D2F9C2F65A18407B1D2B764F130847F8B5D"
+
+        assertTrue(CustomBridgeBottomSheet.isValidBridge(obfs4))
+        assertTrue(CustomBridgeBottomSheet.isValidBridge(vanilla))
+    }
+
+    @Test
+    fun crlfSeparatedBridgesValidateAndSaveClean() {
+        val input = "192.0.2.5:443 D9A82D2F9C2F65A18407B1D2B764F130847F8B5D\r\n" +
+                "192.0.2.6:443 A998F319ADB60EE344540EC4B21524CC484F96BE"
+
+        assertTrue(CustomBridgeBottomSheet.isValidBridge(input))
+        val lines = CustomBridgeBottomSheet.cleanBridgeLines(input)
+        assertEquals(2, lines.size)
+        assertFalse(lines.any { it.contains("\r") })
+    }
+
+    @Test
+    fun blankLinesAreDroppedFromCleanedBridges() {
+        val input = "192.0.2.5:443 D9A82D2F9C2F65A18407B1D2B764F130847F8B5D\n\n" +
+                "192.0.2.6:443 A998F319ADB60EE344540EC4B21524CC484F96BE\n"
+
+        assertTrue(CustomBridgeBottomSheet.isValidBridge(input))
+        assertEquals(2, CustomBridgeBottomSheet.cleanBridgeLines(input).size)
+    }
+
+    @Test
+    fun malformedLineIsStillRejected() {
+        assertFalse(CustomBridgeBottomSheet.isValidBridge("this is not a bridge line"))
+    }
+
+    @Test
+    fun cleanBridgeLinesReplacesUnicodeSpacesOnly() {
+        val input = "dnstt${nbsp}192.0.2.4:1${nbsp}A998F319ADB60EE344540EC4B21524CC484F96BE" +
+                "${nbsp}pubkey=241169008830694749fe96bb070c4855c5bb5b9c47b3833ed7d88521ba30a43f" +
+                "${nbsp}domain=t.ruhnama.net"
+        val expected = "dnstt 192.0.2.4:1 A998F319ADB60EE344540EC4B21524CC484F96BE " +
+                "pubkey=241169008830694749fe96bb070c4855c5bb5b9c47b3833ed7d88521ba30a43f " +
+                "domain=t.ruhnama.net"
+
+        assertEquals(listOf(expected), CustomBridgeBottomSheet.cleanBridgeLines(input))
+    }
+}


### PR DESCRIPTION
Fixes #1695

HTML email (Tor's dnstt bridge templates in particular) swaps in a non-breaking space where a regular space belongs once the bridge line gets copied out. validBridgeRegex uses \s. That's ASCII-only in Java/Kotlin regex. Bridge.kt splits on a literal " ". A stray U+00A0 anywhere in the line fails validation, or gets saved and parses wrong later.

This normalizes any Unicode space character to a regular space before we validate or save what's pasted into the custom bridges field. While in there it also puts validation and saving through one cleanBridgeLines path: before this, isValidBridge split with lines() and dropped blanks while the save handler split on a bare \n with no filter, so a CRLF paste could validate fine but store lines with a trailing \r, and blank separator lines got stored as empty entries.

Added unit tests for NBSP-contaminated obfs4 and vanilla lines, CRLF input, blank-line dropping, and a no-regression case for plain ASCII, matching BridgeTest.kt's style.

No Android SDK on this box, so no full gradle build. Verified the regex and normalization logic standalone with kotlinc: the NBSP line fails against the unmodified regex, passes after the fix, plain ASCII behaves exactly as before, and cleaned CRLF input comes out with no \r.
