### PR TITLE
add ipv6Pref to HTTPTunnelPort

### DIFF
--- a/app/src/main/java/org/torproject/android/service/tor/TorConfig.kt
+++ b/app/src/main/java/org/torproject/android/service/tor/TorConfig.kt
@@ -36,7 +36,7 @@ object TorConfig {
 
         conf.add("SafeSocks 0")
         conf.add("TestSocks 0")
-        conf.add("HTTPTunnelPort $httpPortPref $isolate")
+        conf.add("HTTPTunnelPort $httpPortPref $ipv6Pref $isolate")
 
         if (Prefs.connectionPadding) {
             conf.add("ConnectionPadding 1")


### PR DESCRIPTION
Fixes #1420

SOCKSPort gets $ipv6Pref appended in both branches (open-on-all-interfaces and the default) so IPv6Traffic/PreferIPv6/NoIPv4Traffic follow whatever the user picked in the UI, but HTTPTunnelPort was missing the same flags, so the IPv6 setting never reached the http tunnel.

One-line fix, appends $ipv6Pref to the HTTPTunnelPort line the same way SOCKSPort already does.

The tor man page only documents isolation flags for HTTPTunnelPort, so I checked the parser before trusting this: in tor's config.c, HTTPTunnelPort is parsed by port_parse_config with CL_PORT_TAKES_HOSTNAMES set, and IPv6Traffic/PreferIPv6 are accepted exactly when that flag is set, same as SocksPort. The flags are valid there even though the man page does not list them.

No JVM-level test for this one. TorConfig.build() reads through Prefs, which needs a real android.content.Context backing SharedPreferences, and there's no Robolectric (or similar) in this project to fake that at the JVM level, so a meaningful unit test here would mean adding a chunk of test infrastructure for a one-line change.
