### PR TITLE
Fix ContentProvider update and use consistent APIs

### DIFF
--- a/app/src/main/java/org/torproject/android/ui/v3onionservice/clientauth/ClientAuthActivity.java
+++ b/app/src/main/java/org/torproject/android/ui/v3onionservice/clientauth/ClientAuthActivity.java
@@ -12,12 +12,10 @@ import android.os.Looper;
 import android.provider.OpenableColumns;
 import android.view.Menu;
 import android.view.MenuItem;
-import android.view.WindowManager;
 import android.widget.ListView;
 import android.widget.Toast;
 
 import androidx.annotation.Nullable;
-import androidx.fragment.app.Fragment;
 
 import org.torproject.android.R;
 import org.torproject.android.util.DiskUtils;
@@ -25,7 +23,6 @@ import org.torproject.android.ui.core.BaseActivity;
 import org.torproject.android.service.db.V3ClientAuthColumns;
 import org.torproject.android.ui.v3onionservice.V3BackupUtils;
 
-import java.util.List;
 import java.util.Objects;
 
 public class ClientAuthActivity extends BaseActivity {
@@ -45,7 +42,6 @@ public class ClientAuthActivity extends BaseActivity {
     protected void onCreate(@Nullable Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_v3auth);
-        getWindow().setFlags(WindowManager.LayoutParams.FLAG_SECURE, WindowManager.LayoutParams.FLAG_SECURE);
 
         setSupportActionBar(findViewById(R.id.toolbar));
         Objects.requireNonNull(getSupportActionBar()).setDisplayHomeAsUpEnabled(true);
@@ -72,6 +68,7 @@ public class ClientAuthActivity extends BaseActivity {
 
     @Override
     public void onActivityResult(int requestCode, int resultCode, Intent data) {
+        super.onActivityResult(requestCode, resultCode, data);
         if (requestCode == REQUEST_CODE_READ_ZIP_BACKUP && resultCode == RESULT_OK) {
             Uri uri = data.getData();
             if (uri != null) {
@@ -88,10 +85,6 @@ public class ClientAuthActivity extends BaseActivity {
                 String authText = DiskUtils.readFileFromInputStream(getContentResolver(), uri);
                 new V3BackupUtils(this).restoreClientAuthBackup(authText);
             }
-        } else {
-            super.onActivityResult(requestCode, resultCode, data);
-            List<Fragment> frags = getSupportFragmentManager().getFragments();
-            for (Fragment f : frags) f.onActivityResult(requestCode, resultCode, data);
         }
     }
 

--- a/app/src/main/java/org/torproject/android/ui/v3onionservice/clientauth/ClientAuthBackupDialogFragment.java
+++ b/app/src/main/java/org/torproject/android/ui/v3onionservice/clientauth/ClientAuthBackupDialogFragment.java
@@ -1,9 +1,7 @@
 package org.torproject.android.ui.v3onionservice.clientauth;
 
-import android.app.Activity;
 import android.app.Dialog;
 import android.content.DialogInterface;
-import android.content.Intent;
 import android.net.Uri;
 import android.os.Bundle;
 import android.text.Editable;
@@ -13,13 +11,14 @@ import android.view.ViewGroup;
 import android.widget.FrameLayout;
 import android.widget.Toast;
 
+import androidx.activity.result.ActivityResultLauncher;
+import androidx.activity.result.contract.ActivityResultContracts;
 import androidx.annotation.NonNull;
 import androidx.appcompat.app.AlertDialog;
 import androidx.core.content.ContextCompat;
 import androidx.fragment.app.DialogFragment;
 
 import org.torproject.android.R;
-import org.torproject.android.util.DiskUtils;
 import org.torproject.android.ui.core.NoPersonalizedLearningEditText;
 import org.torproject.android.ui.v3onionservice.V3BackupUtils;
 
@@ -31,6 +30,10 @@ public class ClientAuthBackupDialogFragment extends DialogFragment {
     private TextWatcher fileNameTextWatcher;
 
     private static final String BUNDLE_KEY_FILENAME = "filename";
+
+    private final ActivityResultLauncher<String> createDocumentLauncher = registerForActivityResult(
+        new ActivityResultContracts.CreateDocument(ClientAuthActivity.CLIENT_AUTH_SAF_MIME_TYPE), uri -> attemptToWriteBackup(uri)
+    );
 
     public ClientAuthBackupDialogFragment() {
     }
@@ -104,20 +107,11 @@ public class ClientAuthBackupDialogFragment extends DialogFragment {
         String filename = Objects.requireNonNull(etFilename.getText()).toString().trim();
         if (!filename.endsWith(ClientAuthActivity.CLIENT_AUTH_FILE_EXTENSION))
             filename += ClientAuthActivity.CLIENT_AUTH_FILE_EXTENSION;
-        Intent createFileIntent = DiskUtils.createWriteFileIntent(filename, ClientAuthActivity.CLIENT_AUTH_SAF_MIME_TYPE);
-        requireActivity().startActivityForResult(createFileIntent, REQUEST_CODE_WRITE_FILE);
-    }
-
-    @Override
-    public void onActivityResult(int requestCode, int resultCode, Intent data) {
-        if (requestCode == REQUEST_CODE_WRITE_FILE && resultCode == Activity.RESULT_OK) {
-            if (data != null) {
-                attemptToWriteBackup(data.getData());
-            }
-        }
+        createDocumentLauncher.launch(filename);
     }
 
     private void attemptToWriteBackup(Uri outputFile) {
+        if (outputFile == null) return;
         assert getArguments() != null;
         var v3BackupUtils = new V3BackupUtils(getContext());
         var domain = getArguments().getString(ClientAuthActivity.BUNDLE_KEY_DOMAIN);
@@ -126,6 +120,4 @@ public class ClientAuthBackupDialogFragment extends DialogFragment {
         Toast.makeText(getContext(), backup != null ? R.string.backup_saved_at_external_storage : R.string.error, Toast.LENGTH_LONG).show();
         dismiss();
     }
-
-    private static final int REQUEST_CODE_WRITE_FILE = 432;
 }

--- a/app/src/main/java/org/torproject/android/ui/v3onionservice/clientauth/ClientAuthContentProvider.java
+++ b/app/src/main/java/org/torproject/android/ui/v3onionservice/clientauth/ClientAuthContentProvider.java
@@ -86,7 +86,7 @@ public class ClientAuthContentProvider extends ContentProvider {
     public int update(@NonNull Uri uri, @Nullable ContentValues values, @Nullable String selection, @Nullable String[] selectionArgs) {
         SQLiteDatabase db = mDatabase.getWritableDatabase();
         if (uriMatcher.match(uri) == V3AUTH_ID)
-            selection = "id_=" + uri.getLastPathSegment();
+            selection = "_id=" + uri.getLastPathSegment();
         int rows = db.update(ClientAuthDatabase.DATABASE_NAME, values, selection, null);
         Objects.requireNonNull(getContext()).getContentResolver().notifyChange(CONTENT_URI, null);
         return rows;


### PR DESCRIPTION
- Fix per-id update selection typo in ClientAuthContentProvider (id_ → _id)
- Simplify ClientAuthActivity: drop redundant fragment result-forwarding loop and unconditional FLAG_SECURE override, prune unused imports
- Modernize ClientAuthBackupDialogFragment: switch SAF export from deprecated startActivityForResult to ActivityResultContracts.CreateDocument; remove onActivityResult, REQUEST_CODE_WRITE_FILE, and unused imports