### PR TITLE
Use white icons in the status bar

### DIFF
--- a/app/src/main/java/org/torproject/android/ui/v3onionservice/OnionServiceActivity.java
+++ b/app/src/main/java/org/torproject/android/ui/v3onionservice/OnionServiceActivity.java
@@ -19,6 +19,7 @@ import androidx.activity.result.contract.ActivityResultContracts;
 import androidx.annotation.NonNull;
 import androidx.appcompat.widget.Toolbar;
 import androidx.coordinatorlayout.widget.CoordinatorLayout;
+import androidx.core.view.WindowCompat;
 
 import com.google.android.material.floatingactionbutton.FloatingActionButton;
 
@@ -46,6 +47,7 @@ public class OnionServiceActivity extends BaseActivity {
     @Override
     public void onCreate(Bundle bundle) {
         super.onCreate(bundle);
+        WindowCompat.getInsetsController(getWindow(), getWindow().getDecorView()).setAppearanceLightStatusBars(false);
         setContentView(R.layout.activity_hosted_services);
         getWindow().setFlags(WindowManager.LayoutParams.FLAG_SECURE, WindowManager.LayoutParams.FLAG_SECURE);
 

--- a/app/src/main/java/org/torproject/android/ui/v3onionservice/clientauth/ClientAuthActivity.java
+++ b/app/src/main/java/org/torproject/android/ui/v3onionservice/clientauth/ClientAuthActivity.java
@@ -18,6 +18,7 @@ import android.widget.Toast;
 import androidx.activity.result.ActivityResultLauncher;
 import androidx.activity.result.contract.ActivityResultContracts;
 import androidx.annotation.Nullable;
+import androidx.core.view.WindowCompat;
 
 import org.torproject.android.R;
 import org.torproject.android.service.db.V3ClientAuthColumns;
@@ -49,6 +50,7 @@ public class ClientAuthActivity extends BaseActivity {
     @Override
     protected void onCreate(@Nullable Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+        WindowCompat.getInsetsController(getWindow(), getWindow().getDecorView()).setAppearanceLightStatusBars(false);
         setContentView(R.layout.activity_v3auth);
         // always prevent this screen from being screenshotted, regardless of the preference for screenshotting
         getWindow().setFlags(WindowManager.LayoutParams.FLAG_SECURE, WindowManager.LayoutParams.FLAG_SECURE);


### PR DESCRIPTION
Hosted Onion Services and Client Authorization screens are ignoring the theme settting when determining if the status bar icons should be white or black.