### PR TITLE
Register the kindness network callback per the Wi-Fi pref

### DIFF
--- a/app/src/main/java/org/torproject/android/ui/kindness/SnowflakeProxyService.kt
+++ b/app/src/main/java/org/torproject/android/ui/kindness/SnowflakeProxyService.kt
@@ -144,10 +144,16 @@ class SnowflakeProxyService : Service() {
                 }
             }
         }
-        connectivityManager.registerNetworkCallback(
-            NetworkRequest.Builder().addCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)
-                .addTransportType(NetworkCapabilities.TRANSPORT_WIFI).build(), networkCallbacks
-        )
+        // A Wi-Fi-filtered callback never fires on cellular, so it can only be used
+        // when proxying is limited to Wi-Fi.
+        if (Prefs.limitSnowflakeProxyingWifi()) {
+            connectivityManager.registerNetworkCallback(
+                NetworkRequest.Builder().addCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)
+                    .addTransportType(NetworkCapabilities.TRANSPORT_WIFI).build(), networkCallbacks
+            )
+        } else {
+            connectivityManager.registerDefaultNetworkCallback(networkCallbacks)
+        }
     }
 
     private fun createNotificationChannel(): String {


### PR DESCRIPTION
Follow-up to 98a0cf3 (#1798). Filtering the network callback to TRANSPORT_WIFI fixed Wi-Fi being ignored while tor's VPN is active, but the "only when on Wi-Fi" switch in the kindness config sheet is still there and can be turned off. With it off:

- on a cellular-only connection, `onAvailable` never fires (the request only matches Wi-Fi networks), so network events never start the proxy and the notification sits at "starting"
- when Wi-Fi drops while cellular stays up, `onLost` stops the proxy and no event restarts it until Wi-Fi comes back

The `limitSnowflakeProxyingWifi() && !hasWifi` check in `onAvailable` also can't do anything under the filter, since every network it sees is Wi-Fi.

This keeps the Wi-Fi-filtered registration when the pref is on, so the VPN fix stays, and goes back to `registerDefaultNetworkCallback` when it's off, the single-tracked-network behavior this handler was written for. The service restarts when the config sheet changes a setting (the `KEY_CONFIG_CHANGED` listener in `KindnessFragment` double-toggles the switch), so the registration always matches the pref. `onDestroy`'s `unregisterNetworkCallback` covers both registration paths.

Compiles and the unit tests pass. I don't have a cellular device to hand, so a quick check on hardware with the Wi-Fi switch off would be a good sanity pass.
