### PR TITLE
Fix log lines being stored in duplicate

### DIFF
--- a/app/src/main/java/org/torproject/android/service/OrbotService.java
+++ b/app/src/main/java/org/torproject/android/service/OrbotService.java
@@ -64,6 +64,7 @@ import androidx.core.app.NotificationCompat;
 import androidx.core.app.ServiceCompat;
 import androidx.core.content.ContextCompat;
 
+import net.freehaven.tor.control.RawEventListener;
 import net.freehaven.tor.control.TorControlCommands;
 import net.freehaven.tor.control.TorControlConnection;
 
@@ -86,6 +87,7 @@ import java.util.Locale;
 import java.util.StringTokenizer;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import kotlin.Unit;
 
@@ -103,6 +105,7 @@ public class OrbotService extends VpnService {
     protected String mCurrentStatus = STATUS_OFF;
     TorControlConnection conn = null;
     private ServiceConnection torServiceConnection;
+    private final AtomicBoolean torStartRequested = new AtomicBoolean(false);
     private volatile boolean shouldUnbindTorService;
     private NotificationManager mNotificationManager = null;
     private NotificationCompat.Builder mNotifyBuilder;
@@ -232,6 +235,7 @@ public class OrbotService extends VpnService {
 
     private void stopTorOnError(String message) {
         //  stopTorAsync(false);
+        torStartRequested.set(false);
         showToolbarNotification(getString(R.string.unable_to_start_tor) + ": " + message, ERROR_NOTIFY_ID, R.drawable.ic_stat_notifyerr);
     }
 
@@ -258,6 +262,9 @@ public class OrbotService extends VpnService {
         } else {
             sendLocalStatusOffBroadcast();
         }
+
+        torServiceConnection = null;
+        torStartRequested.set(false);
     }
 
     private void requestTorRereadConfig() {
@@ -382,10 +389,13 @@ public class OrbotService extends VpnService {
 
     // The entire process for starting tor and related services is run from this method.
     private void startTor() {
-        if (torServiceConnection != null && conn != null) {
+        // conn stays null for the whole bind window, so it cannot be the re-entrancy guard
+        if (!torStartRequested.compareAndSet(false, true)) {
             Log.d(TAG, "already started, ignoring start request");
-            mNotifyBuilder.setProgress(0, 0, false);
-            showToolbarNotification(getString(R.string.status_activated), NOTIFY_ID, R.drawable.ic_stat_tor);
+            if (conn != null) {
+                mNotifyBuilder.setProgress(0, 0, false);
+                showToolbarNotification(getString(R.string.status_activated), NOTIFY_ID, R.drawable.ic_stat_tor);
+            }
             return;
         }
         mNotifyBuilder.setProgress(100, 0, false);
@@ -462,7 +472,10 @@ public class OrbotService extends VpnService {
                 """, false);
 
         var fileTorrcCustom = updateTorrcCustomFile();
-        if ((!fileTorrcCustom.exists()) || (!fileTorrcCustom.canRead())) return;
+        if ((!fileTorrcCustom.exists()) || (!fileTorrcCustom.canRead())) {
+            torStartRequested.set(false);
+            return;
+        }
 
         sendCallbackLogMessage(getString(R.string.status_starting_up));
 
@@ -486,6 +499,7 @@ public class OrbotService extends VpnService {
                     Log.e(TAG, e.toString());
                 }
 
+                var staleListener = mOrbotRawEventListener;
                 mOrbotRawEventListener = new OrbotRawEventListener(OrbotService.this);
 
                 if (conn == null) return;
@@ -494,8 +508,7 @@ public class OrbotService extends VpnService {
                     if (conn == null)
                         return; // maybe there was an error setting up the control connection
 
-                    //override the TorService event listener
-                    conn.addRawEventListener(mOrbotRawEventListener);
+                    replaceRawEventListener(conn, staleListener, mOrbotRawEventListener);
 
                     logNotice(getString(R.string.status_connected_control_port));
 
@@ -520,6 +533,16 @@ public class OrbotService extends VpnService {
             @Override
             public void onBindingDied(ComponentName componentName) {
                 Log.w(TAG, "TorService: onBindingDied");
+                // a died binding never reconnects, so release it and let the next start request through
+                if (torServiceConnection == this) {
+                    if (shouldUnbindTorService) {
+                        unbindService(this);
+                        shouldUnbindTorService = false;
+                    }
+                    conn = null;
+                    torServiceConnection = null;
+                    torStartRequested.set(false);
+                }
                 sendLocalStatusOffBroadcast();
             }
         };
@@ -530,6 +553,16 @@ public class OrbotService extends VpnService {
             shouldUnbindTorService = bindService(serviceIntent, BIND_AUTO_CREATE, mExecutor, torServiceConnection);
         else
             shouldUnbindTorService = bindService(serviceIntent, torServiceConnection, BIND_AUTO_CREATE);
+        if (!shouldUnbindTorService) {
+            torServiceConnection = null;
+            stopTorOnError("bindService failed");
+        }
+    }
+
+    // jtorctl's addRawEventListener is a plain List.add, so re-adding duplicates every event
+    static void replaceRawEventListener(TorControlConnection conn, RawEventListener staleListener, RawEventListener freshListener) {
+        if (staleListener != null) conn.removeRawEventListener(staleListener);
+        conn.addRawEventListener(freshListener);
     }
 
     private void sendLocalStatusOffBroadcast() {

--- a/app/src/main/java/org/torproject/android/ui/more/LogBottomSheet.kt
+++ b/app/src/main/java/org/torproject/android/ui/more/LogBottomSheet.kt
@@ -25,6 +25,8 @@ class LogBottomSheet : OrbotBottomSheetDialogFragment() {
         PreferenceManager
             .getDefaultSharedPreferences(requireContext())
             .registerOnSharedPreferenceChangeListener(logPrefObserver)
+        binding.orbotLog.text = Prefs.getOrbotServiceLog()
+        scrollToBottom()
     }
 
     override fun onStop() {
@@ -59,9 +61,8 @@ class LogBottomSheet : OrbotBottomSheetDialogFragment() {
         SharedPreferences.OnSharedPreferenceChangeListener { sharedPrefs, key ->
             if (key != Prefs.PREF_ORBOT_SERVICE_LOG) return@OnSharedPreferenceChangeListener
             val newLog = Prefs.getOrbotServiceLog()
-            if (newLog.length > binding.orbotLog.text.length) {
-                binding.orbotLog.append(newLog.substring(binding.orbotLog.text.length))
-            } else binding.orbotLog.text = newLog
+            val delta = appendableDelta(binding.orbotLog.text.toString(), newLog)
+            if (delta != null) binding.orbotLog.append(delta) else binding.orbotLog.text = newLog
             scrollToBottom()
         }
 
@@ -70,6 +71,12 @@ class LogBottomSheet : OrbotBottomSheetDialogFragment() {
         fun show(fragmentManager: FragmentManager) {
             LogBottomSheet().show(fragmentManager, TAG)
         }
+
+        // the service clears and regrows the stored log across restarts, so longer does not mean grown
+        fun appendableDelta(displayed: String, stored: String): String? =
+            if (stored.length > displayed.length && stored.startsWith(displayed))
+                stored.substring(displayed.length)
+            else null
     }
 
 }

--- a/app/src/test/java/org/torproject/android/service/OrbotServiceRawEventListenerTest.kt
+++ b/app/src/test/java/org/torproject/android/service/OrbotServiceRawEventListenerTest.kt
@@ -1,0 +1,77 @@
+package org.torproject.android.service
+
+import net.freehaven.tor.control.RawEventListener
+import net.freehaven.tor.control.TorControlConnection
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.io.ByteArrayOutputStream
+import java.io.PipedInputStream
+import java.io.PipedOutputStream
+import java.util.Collections
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+
+class OrbotServiceRawEventListenerTest {
+
+    private fun connectionOver(feed: PipedOutputStream) =
+        TorControlConnection(PipedInputStream(feed), ByteArrayOutputStream())
+
+    private fun sendNotice(feed: PipedOutputStream, message: String) {
+        feed.write("650 NOTICE $message\r\n".toByteArray())
+        feed.flush()
+    }
+
+    @Test
+    fun secondConnectDeliversEachEventOnce() {
+        val feed = PipedOutputStream()
+        val conn = connectionOver(feed)
+
+        val delivered = Collections.synchronizedList(mutableListOf<String>())
+        val sawMarker = CountDownLatch(1)
+        val record = RawEventListener { keyword, data ->
+            if (keyword == "NOTICE") {
+                delivered.add(data)
+                if (data == "marker") sawMarker.countDown()
+            }
+        }
+        val first = RawEventListener { keyword, data -> record.onEvent(keyword, data) }
+        val second = RawEventListener { keyword, data -> record.onEvent(keyword, data) }
+
+        OrbotService.replaceRawEventListener(conn, null, first)
+        OrbotService.replaceRawEventListener(conn, first, second)
+        conn.launchThread(true)
+
+        sendNotice(feed, "Bootstrapped 45%")
+        sendNotice(feed, "marker")
+
+        assertTrue(sawMarker.await(5, TimeUnit.SECONDS))
+        assertEquals(listOf("Bootstrapped 45%", "marker"), delivered)
+    }
+
+    @Test
+    fun repeatedReconnectsKeepASingleListener() {
+        val feed = PipedOutputStream()
+        val conn = connectionOver(feed)
+
+        val delivered = Collections.synchronizedList(mutableListOf<String>())
+        val sawMarker = CountDownLatch(1)
+        var previous: RawEventListener? = null
+        repeat(4) {
+            val listener = RawEventListener { keyword, data ->
+                if (keyword == "NOTICE") {
+                    delivered.add(data)
+                    if (data == "marker") sawMarker.countDown()
+                }
+            }
+            OrbotService.replaceRawEventListener(conn, previous, listener)
+            previous = listener
+        }
+        conn.launchThread(true)
+
+        sendNotice(feed, "marker")
+
+        assertTrue(sawMarker.await(5, TimeUnit.SECONDS))
+        assertEquals(listOf("marker"), delivered)
+    }
+}

--- a/app/src/test/java/org/torproject/android/ui/more/LogBottomSheetTest.kt
+++ b/app/src/test/java/org/torproject/android/ui/more/LogBottomSheetTest.kt
@@ -1,0 +1,45 @@
+package org.torproject.android.ui.more
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class LogBottomSheetTest {
+
+    @Test
+    fun growingLogAppendsOnlyTheNewTail() {
+        val displayed = "\nBootstrapped 10%"
+        val stored = "\nBootstrapped 10%\nBootstrapped 45%"
+
+        assertEquals("\nBootstrapped 45%", LogBottomSheet.appendableDelta(displayed, stored))
+    }
+
+    @Test
+    fun coalescedGrowthAppendsAllMissedLines() {
+        val displayed = "\nBootstrapped 10%"
+        val stored = "\nBootstrapped 10%\nBootstrapped 45%\nBootstrapped 100%"
+
+        assertEquals(
+            "\nBootstrapped 45%\nBootstrapped 100%",
+            LogBottomSheet.appendableDelta(displayed, stored)
+        )
+    }
+
+    @Test
+    fun clearedAndRegrownLogIsNotSplicedIntoStaleText() {
+        val displayed = "\nold session line one\nold session line two"
+        val stored = "\nnew session first line\nnew session second line\nnew session third line"
+
+        assertNull(LogBottomSheet.appendableDelta(displayed, stored))
+    }
+
+    @Test
+    fun shorterStoredLogReplacesDisplayedText() {
+        assertNull(LogBottomSheet.appendableDelta("\nline one\nline two", "\nline one"))
+    }
+
+    @Test
+    fun unchangedLogAppendsNothing() {
+        assertNull(LogBottomSheet.appendableDelta("\nline one", "\nline one"))
+    }
+}


### PR DESCRIPTION
Every log line can end up stored two or more times, and the doubling survives closing and reopening the log sheet. n8fr8 mentioned in the Matrix room yesterday that this one was never pinned down, so I went digging.

The duplication is in storage, not display. startTor() guards re-entry with `torServiceConnection != null && conn != null`, but conn stays null for the whole bind window (longer with Smart Connect), and every ACTION_START runs through the cached thread pool. Two start intents inside that window, say the boot receiver plus an always-on VPN system start, both pass the guard, so the service binds twice and each onServiceConnected() adds its own OrbotRawEventListener to the same TorControlConnection. jtorctl's addRawEventListener is a plain List.add, so from then on every tor event is appended to the stored log once per listener. That is why the doubled lines survive the sheet being reopened and survived the UI rewrite. stopTor() also never nulled torServiceConnection, so the stacking can compound across restarts; the "Service not registered: OrbotService$2" crash in #1404 looks like the same stale state.

I proved the listener half on the JVM against jtorctl 0.4.5.7: one control connection, two registered listeners, one 650 NOTICE in, two identical appends out. The new unit tests drive a real TorControlConnection over piped streams and fail on the old logic.

To see it on a device: enable start on boot plus always-on VPN and reboot. "Connected to the Tor control port" shows up twice and every line after it is doubled.

What this changes:

- startTor() is single flight across the bind window. The flag is released on every path that kills the attempt, including a bind that returns false and a binding the system reports dead, so a failed start cannot wedge the service into ignoring later starts.
- stopTor() nulls torServiceConnection.
- onServiceConnected() removes the stale raw event listener before adding the fresh one, so even a bind path the guard does not cover cannot log an event twice.
- The log sheet only appends the stored-log delta when the stored text actually extends what is on screen, and re-reads the stored log when it returns to the foreground. A backgrounded sheet across a service restart used to splice stale text once the new log outgrew the old.

All 28 unit tests pass, and the two new suites fail against the unfixed logic.
