### PR TITLE
Fix Kindness mode preference listener

### DIFF
--- a/app/src/main/java/org/torproject/android/ui/kindness/SnowflakeProxyPreference.kt
+++ b/app/src/main/java/org/torproject/android/ui/kindness/SnowflakeProxyPreference.kt
@@ -1,0 +1,6 @@
+package org.torproject.android.ui.kindness
+
+import org.torproject.android.util.Prefs
+
+internal fun shouldIgnoreSnowflakePreferenceChange(key: String?): Boolean =
+    key != Prefs.PREF_BRIDGE_COUNTRY && key != Prefs.PREF_CAMO_APP_PACKAGE

--- a/app/src/main/java/org/torproject/android/ui/kindness/SnowflakeProxyService.kt
+++ b/app/src/main/java/org/torproject/android/ui/kindness/SnowflakeProxyService.kt
@@ -49,7 +49,7 @@ class SnowflakeProxyService : Service() {
         powerConnectionReceiver = PowerConnectionReceiver(this)
         regionChangedObserver =
             SharedPreferences.OnSharedPreferenceChangeListener { sharedPreferences, key ->
-                if (key != Prefs.PREF_BRIDGE_COUNTRY || key != Prefs.PREF_CAMO_APP_PACKAGE) return@OnSharedPreferenceChangeListener
+                if (shouldIgnoreSnowflakePreferenceChange(key)) return@OnSharedPreferenceChangeListener
                 if (key == Prefs.PREF_CAMO_APP_PACKAGE) {
                     refreshNotification()
                 } else if (Regionalization.isKindnessModeDisabledForCountry(Prefs.bridgeCountry)) {

--- a/app/src/test/java/org/torproject/android/ui/kindness/SnowflakeProxyServiceTest.kt
+++ b/app/src/test/java/org/torproject/android/ui/kindness/SnowflakeProxyServiceTest.kt
@@ -1,0 +1,20 @@
+package org.torproject.android.ui.kindness
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.torproject.android.util.Prefs
+
+class SnowflakeProxyServiceTest {
+    @Test
+    fun relevantPreferenceChangesAreHandled() {
+        assertFalse(shouldIgnoreSnowflakePreferenceChange(Prefs.PREF_BRIDGE_COUNTRY))
+        assertFalse(shouldIgnoreSnowflakePreferenceChange(Prefs.PREF_CAMO_APP_PACKAGE))
+    }
+
+    @Test
+    fun unrelatedPreferenceChangesAreIgnored() {
+        assertTrue(shouldIgnoreSnowflakePreferenceChange("unrelated_preference"))
+        assertTrue(shouldIgnoreSnowflakePreferenceChange(null))
+    }
+}


### PR DESCRIPTION
Fixes #1808.

The Snowflake proxy preference listener returned early for every key because the two negative key checks were joined with `||`. This meant bridge-country changes never stopped Kindness mode in countries where it is disabled, and camo-app changes never refreshed the notification.

Use a small predicate with the correct `&&` semantics and add regression coverage for both relevant preference keys as well as unrelated/null keys.

Tests:
- regression test reproduced the current OR-guard failure before the fix
- `./gradlew :app:testFullpermDebugUnitTest`
- `./gradlew :app:assembleFullpermDebug`
- `git diff --check`