### PR TITLE
Handle unavailable preference provider

### DIFF
--- a/app/src/main/java/org/torproject/android/util/PreferenceProvider.kt
+++ b/app/src/main/java/org/torproject/android/util/PreferenceProvider.kt
@@ -106,17 +106,30 @@ class PreferenceProvider: ContentProvider() {
     }
 }
 
-private fun <T> ContentResolver.getPref(key: String, converter: (Cursor, Int) -> T?): T? {
-    val cursor = query(Uri.withAppendedPath(PreferenceProvider.CONTENT_URI, key),
-        null, null, null, null) ?: return null
-
-    cursor.use {
-        if (it.moveToFirst()) {
-            return converter(it, it.getColumnIndex(PreferenceProvider.ROW_VALUE))
-        }
+internal fun <T> preferenceProviderCall(defaultValue: T, action: () -> T): T =
+    try {
+        action()
+    } catch (_: IllegalArgumentException) {
+        defaultValue
     }
 
-    return null
+private fun <T> ContentResolver.getPref(key: String, converter: (Cursor, Int) -> T?): T? {
+    return preferenceProviderCall<T?>(null) {
+        val cursor = query(
+            Uri.withAppendedPath(PreferenceProvider.CONTENT_URI, key),
+            null, null, null, null
+        ) ?: return@preferenceProviderCall null
+
+        cursor.use {
+            if (it.moveToFirst()) {
+                return@preferenceProviderCall converter(
+                    it, it.getColumnIndex(PreferenceProvider.ROW_VALUE)
+                )
+            }
+        }
+
+        null
+    }
 }
 
 fun ContentResolver.getPrefString(key: String, default: String? = null): String? {
@@ -143,8 +156,13 @@ fun ContentResolver.getPrefFloat(key: String, default: Float? = null): Float? {
 }
 
 private fun ContentResolver.putPref(key: String, values: ContentValues) {
-    update(Uri.withAppendedPath(PreferenceProvider.CONTENT_URI, key),
-        values, null, null)
+    preferenceProviderCall(Unit) {
+        update(
+            Uri.withAppendedPath(PreferenceProvider.CONTENT_URI, key),
+            values, null, null
+        )
+        Unit
+    }
 }
 
 fun ContentResolver.putPref(key: String, value: String?) {

--- a/app/src/test/java/org/torproject/android/util/PreferenceProviderTest.kt
+++ b/app/src/test/java/org/torproject/android/util/PreferenceProviderTest.kt
@@ -1,0 +1,28 @@
+package org.torproject.android.util
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class PreferenceProviderTest {
+    @Test
+    fun providerCallReturnsSuccessfulResult() {
+        assertEquals("value", preferenceProviderCall("fallback") { "value" })
+    }
+
+    @Test
+    fun providerCallFallsBackWhenProviderIsUnavailable() {
+        assertEquals(
+            "fallback",
+            preferenceProviderCall("fallback") {
+                throw IllegalArgumentException("Unknown URI")
+            }
+        )
+    }
+
+    @Test(expected = IllegalStateException::class)
+    fun providerCallDoesNotHideUnrelatedRuntimeFailures() {
+        preferenceProviderCall(Unit) {
+            throw IllegalStateException("unrelated failure")
+        }
+    }
+}


### PR DESCRIPTION
Fixes #1760.

Preference reads and writes use a ContentProvider because OrbotService runs in the `:tor` process. If Android cannot resolve the provider URI, `ContentResolver` throws `IllegalArgumentException`; the service-log path currently lets that exception escape and crash the Tor control thread.

Treat that specific resolver failure as an unavailable preference provider: reads fall back to their existing defaults and writes become no-ops. Other runtime exceptions still propagate.

Tests:
- regression test reproduces the provider failure before the fallback
- `./gradlew :app:testFullpermDebugUnitTest`
- `./gradlew :app:assembleFullpermDebug`
- `git diff --check`