### PR TITLE
Show configured proxy ports independently

### DIFF
--- a/app/src/main/java/org/torproject/android/OrbotActivity.kt
+++ b/app/src/main/java/org/torproject/android/OrbotActivity.kt
@@ -282,11 +282,11 @@ class OrbotActivity : BaseActivity() {
                 }
 
                 OrbotConstants.LOCAL_ACTION_PORTS -> {
-                    val socks = intent.getIntExtra(OrbotConstants.EXTRA_SOCKS_PROXY_PORT, -1)
-                    val http = intent.getIntExtra(OrbotConstants.EXTRA_HTTP_PROXY_PORT, -1)
-                    if (http > 0 && socks > 0) {
-                        portSocks = socks
-                        portHttp = http
+                    if (intent.hasExtra(OrbotConstants.EXTRA_SOCKS_PROXY_PORT)) {
+                        portSocks = intent.getIntExtra(OrbotConstants.EXTRA_SOCKS_PROXY_PORT, -1)
+                    }
+                    if (intent.hasExtra(OrbotConstants.EXTRA_HTTP_PROXY_PORT)) {
+                        portHttp = intent.getIntExtra(OrbotConstants.EXTRA_HTTP_PROXY_PORT, -1)
                     }
                 }
 

--- a/app/src/main/java/org/torproject/android/ui/more/MoreFragment.kt
+++ b/app/src/main/java/org/torproject/android/ui/more/MoreFragment.kt
@@ -23,6 +23,14 @@ import org.torproject.android.ui.v3onionservice.clientauth.ClientAuthActivity
 import org.torproject.android.util.StringUtils
 import org.torproject.jni.TorService
 
+internal fun proxyPortDisplayValues(
+    httpPort: Int,
+    socksPort: Int,
+    notSet: String,
+): Pair<String, String> =
+    (if (httpPort > 0) httpPort.toString() else notSet) to
+        (if (socksPort > 0) socksPort.toString() else notSet)
+
 class MoreFragment : Fragment() {
     private var httpPort = -1
     private var socksPort = -1
@@ -51,17 +59,11 @@ class MoreFragment : Fragment() {
 
         val rows = mutableListOf<String>()
 
-        rows += if (httpPort != -1 && socksPort != -1) {
-            listOf(
-                row(labelHttp, httpPort.toString()),
-                row(labelSocks, socksPort.toString())
-            )
-        } else {
-            listOf(
-                row(labelHttp, notSet),
-                row(labelSocks, notSet)
-            )
-        }
+        val (httpValue, socksValue) = proxyPortDisplayValues(httpPort, socksPort, notSet)
+        rows += listOf(
+            row(labelHttp, httpValue),
+            row(labelSocks, socksValue)
+        )
 
         val pm = requireActivity().packageManager
         val info = pm.getPackageInfo(requireActivity().packageName, 0)

--- a/app/src/test/java/org/torproject/android/ui/more/MoreFragmentProxyPortTest.kt
+++ b/app/src/test/java/org/torproject/android/ui/more/MoreFragmentProxyPortTest.kt
@@ -1,0 +1,23 @@
+package org.torproject.android.ui.more
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class MoreFragmentProxyPortTest {
+    private val notSet = "——"
+
+    @Test
+    fun disabledHttpDoesNotHideSocksPort() {
+        assertEquals(notSet to "9050", proxyPortDisplayValues(0, 9050, notSet))
+    }
+
+    @Test
+    fun disabledSocksDoesNotHideHttpPort() {
+        assertEquals("8118" to notSet, proxyPortDisplayValues(8118, 0, notSet))
+    }
+
+    @Test
+    fun activePortsAreBothShown() {
+        assertEquals("8118" to "9050", proxyPortDisplayValues(8118, 9050, notSet))
+    }
+}


### PR DESCRIPTION
Fixes #1134.

The port callback was only saved and displayed when both SOCKS and HTTP ports were enabled. With HTTP disabled (`0`), a valid SOCKS port was therefore shown as unset.

Store and render the two ports independently so disabling one proxy does not hide the other.

Adds regression coverage for the one-port-disabled cases.
