### PR TITLE
Run units tests from actions

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -28,6 +28,9 @@ jobs:
     - name: Build with Gradle
       run: ./gradlew assembleDebug
 
+    - name: Run unit tests
+      run: ./gradlew test
+
     - name: Upload APK
       uses: actions/upload-artifact@v4
       with:


### PR DESCRIPTION
Also, a maintainer has to do `https://github.com/guardianproject/orbot-android/actions/workflows/android.yml → Enable workflow` for this action to correctly work at all.